### PR TITLE
Add snowplow tracking for api-docs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -76,19 +76,6 @@
 
   </footer>
 
-  <!-- build:js scripts/main.min.js -->
-  <script src="scripts/main.js"></script>
-  <script src="scripts/angular.min.js"></script>
-  <script src="scripts/angular-ui-router.min.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0-rc.1/angular-animate.min.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0-rc.1/angular-aria.min.js"></script>
-  <script src="scripts/app.js"></script>
-  <script src="scripts/controllers.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.0/angular-material.min.js"></script>
-  <!-- required for sandbox -->
-  <script src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
-  <script src="scripts/expander.js"></script>
-  <!-- endbuild -->
 
   <script>
     (function(i, s, o, g, r, a, m) {
@@ -106,6 +93,27 @@
     ga('create', 'UA-63640022-1', 'auto');
     //ga('send', 'pageview');
   </script>
+  <script type="text/javascript">
+    (function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
+     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
+     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
+     n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//d78fikflryjgj.cloudfront.net/lib/snowplow/2.0.0.js","sp"));
+    window.sp('newTracker', 'cf', 'd3k1505f61nl3q.cloudfront.net', { appId: 'api-docs', respectDoNotTrack:true });
+  </script>
+
+  <!-- build:js scripts/main.min.js -->
+  <script src="scripts/main.js"></script>
+  <script src="scripts/angular.min.js"></script>
+  <script src="scripts/angular-ui-router.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0-rc.1/angular-animate.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.0-rc.1/angular-aria.min.js"></script>
+  <script src="scripts/app.js"></script>
+  <script src="scripts/controllers.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.0/angular-material.min.js"></script>
+  <!-- required for sandbox -->
+  <script src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
+  <script src="scripts/expander.js"></script>
+  <!-- endbuild -->
 
 </body>
 

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -1,5 +1,15 @@
 var app = angular.module('BuildWithTrelloControllers', []);
 
+app
+.run(['$rootScope', '$location', '$window', function($rootScope, $location, $window){
+  $rootScope.$on('$stateChangeSuccess', function(event){
+    var virtualPath = $location.protocol() + '//' + $location.host() + $location.path();
+    if ($window.sp) {
+      $window.sp('trackPageView', virtualPath);
+    }
+  });
+}]);
+
 app.controller('OverviewCtrl', function($scope) {
 
 });


### PR DESCRIPTION
Hook into angular state change to fire on client side page loads.

We move GA/snowplow before the rest of the script loads. They create
async script tags, won't block rendering, and set up the stubs tracker
functions for queueing before scripts load.
