### PR TITLE
Add links on API Intro page to Authorize and App Key pages

### DIFF
--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -172,7 +172,7 @@ app.controller('SandboxCtrl', function($scope, $http, $sce, $timeout, $window, $
 app.controller('CommunityCtrl', function($scope, $window) {
   $scope.wrappers = [
     {'name':'Ruby',author:'Jeremy Tregunna', url: 'https://github.com/jeremytregunna/ruby-trello'}
-    , {name:'Node', author:'Luca Matteis', url: 'https://github.com/lmatteis/node-trello'}
+    , {name:'Node', author:'Andrew Dunkman', url: 'https://github.com/adunkman/node-trello'}
     , {name:'Python', author:'Richard Kolkovich', url: 'https://github.com/sarumont/py-trello '}
     , {name:'Python', author:'Luke Rigby', url: 'https://github.com/plish/Trolly'}
     , {name:'Python', author:'Brent Tubbs', url: 'https://bitbucket.org/btubbs/trollop'}

--- a/app/templates/apis.html
+++ b/app/templates/apis.html
@@ -23,8 +23,8 @@
 
 	<h2 id="authentication">Authentication and Authorization</h2>
 	<p>There are two steps before your application may make a call on behalf of a user.
-		The first is to get your Application Key. This key identifies your application
-		to Trello, and to your users.</p>
+		The first is to <a href="/app-key">get your Application Key</a>. This key identifies
+		your application to Trello, and to your users.</p>
 	<p>The second step is to perform an authentication and authorization. Trello uses a
 		delegated authentication and authorization flow so that your application never
 		has to deal with storing or handling usernames or passwords. Your application passes
@@ -36,6 +36,7 @@
 		of the authenticated user, based on that user's content and permissions. If you
 		try to access a board or make a change for which the user does not have permission,
 		your request will be blocked.</p>
+	<p><a href="/authorize">Learn more about Authorization</a></p>
 
 	<h2 id="boards">Boards</h2>
 	<a href="/advanced-reference/board">Full Boards API Reference</a>


### PR DESCRIPTION
[The API Intro page](https://developers.trello.com/apis) discusses Authentication and Authorization, but does not link to the [Authorization documentation](https://developers.trello.com/authorize). Because I found the Authorization page to be incredibly helpful, I believe a link to that page would be appropriate.

I did my best to style this in the same manner as the `Webhooks` section lower on the API Intro page.