### PR TITLE
adding defaultLists param to board API docs.

### DIFF
--- a/app/templates/docs/board.html
+++ b/app/templates/docs/board.html
@@ -3247,6 +3247,15 @@
 <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
 </ul>
 </li>
+<li><code class="docutils literal"><span class="pre">defaultLists</span></code> (optional)<ul>
+<li><strong>Default:</strong> <code class="docutils literal"><span class="pre">true</span></code></li>
+<li><strong>Valid Values:</strong><ul>
+<li><code class="docutils literal"><span class="pre">true</span></code></li>
+<li><code class="docutils literal"><span class="pre">false</span></code></li>
+</ul>
+</li>
+</ul>
+</li>
 <li><code class="docutils literal"><span class="pre">desc</span></code> (optional)<ul>
 <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
 </ul>


### PR DESCRIPTION
defaultLists was an unexposed param on the create board method for API, making it evident.