### PR TITLE
remove session reference in API docs.

### DIFF
--- a/app/templates/docs/index.html
+++ b/app/templates/docs/index.html
@@ -331,13 +331,6 @@
 <li class="toctree-l2"><a class="reference internal" href="search/index.html#get-1-search-members">GET /1/search/members</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="session/index.html">session</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="session/index.html#get-1-sessions-socket">GET /1/sessions/socket</a></li>
-<li class="toctree-l2"><a class="reference internal" href="session/index.html#put-1-sessions-idsession">PUT /1/sessions/[idSession]</a></li>
-<li class="toctree-l2"><a class="reference internal" href="session/index.html#put-1-sessions-idsession-status">PUT /1/sessions/[idSession]/status</a></li>
-<li class="toctree-l2"><a class="reference internal" href="session/index.html#post-1-sessions">POST /1/sessions</a></li>
-</ul>
-</li>
 <li class="toctree-l1"><a class="reference internal" href="token/index.html">token</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="token/index.html#get-1-tokens-token">GET /1/tokens/[token]</a></li>
 <li class="toctree-l2"><a class="reference internal" href="token/index.html#get-1-tokens-token-field">GET /1/tokens/[token]/[field]</a></li>


### PR DESCRIPTION
Per Daniel and Brett, the session APIs are skeletons. They need to be removed.