### PR TITLE
Fix quotes

### DIFF
--- a/app/templates/docs/search.html
+++ b/app/templates/docs/search.html
@@ -144,7 +144,7 @@
 </li>
 <li><code class="docutils literal"><span class="pre">card_attachments</span></code> (optional)<ul>
 <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-<li><strong>Valid Values:</strong> A boolean value or &amp;quot;cover&amp;quot; for only card cover attachments</li>
+<li><strong>Valid Values:</strong> A boolean value or &quot;cover&quot; for only card cover attachments</li>
 </ul>
 </li>
 <li><code class="docutils literal"><span class="pre">organization_fields</span></code> (optional)<ul>


### PR DESCRIPTION
Quotes around cover in card_attachment section were showing as &quot; instead of "