### PR TITLE
Quote fix

### DIFF
--- a/app/templates/docs/board.html
+++ b/app/templates/docs/board.html
@@ -239,7 +239,7 @@
         <li><code class="docutils literal"><span class="pre">card_attachments</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-            <li><strong>Valid Values:</strong> A boolean value or &amp;quot;cover&amp;quot; for only card cover attachments</li>
+            <li><strong>Valid Values:</strong> A boolean value or &quot;cover&quot; for only card cover attachments</li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">card_attachment_fields</span></code> (optional)
@@ -1342,7 +1342,7 @@
         <li><code class="docutils literal"><span class="pre">attachments</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-            <li><strong>Valid Values:</strong> A boolean value or &amp;quot;cover&amp;quot; for only card cover attachments</li>
+            <li><strong>Valid Values:</strong> A boolean value or &quot;cover&quot; for only card cover attachments</li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)
@@ -1568,7 +1568,7 @@
         <li><code class="docutils literal"><span class="pre">attachments</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-            <li><strong>Valid Values:</strong> A boolean value or &amp;quot;cover&amp;quot; for only card cover attachments</li>
+            <li><strong>Valid Values:</strong> A boolean value or &quot;cover&quot; for only card cover attachments</li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)
@@ -2507,7 +2507,7 @@
         <li><code class="docutils literal"><span class="pre">attachments</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-            <li><strong>Valid Values:</strong> A boolean value or &amp;quot;cover&amp;quot; for only card cover attachments</li>
+            <li><strong>Valid Values:</strong> A boolean value or &quot;cover&quot; for only card cover attachments</li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)


### PR DESCRIPTION
Anytime the cover filter is explained, the quotes around "cover" show as &quot;