### PR TITLE
Changed [id] to [team or user id]

### DIFF
--- a/app/templates/docs/type.html
+++ b/app/templates/docs/type.html
@@ -1,6 +1,6 @@
 <span id="index"></span><h1>type<a class="headerlink" href="#type" title="Permalink to this headline"></a></h1>
 <div class="section" id="get-1-types-id">
-<h2>GET <span class="target" id="types-id">/1/types/[id]</span><a class="headerlink" href="#get-1-types-id" title="Permalink to this headline"></a></h2>
+<h2>GET <span class="target" id="types-id">/1/types/[team or user id]</span><a class="headerlink" href="#get-1-types-id" title="Permalink to this headline"></a></h2>
 <ul class="simple">
 <li><strong>Required permissions:</strong> read</li>
 <li><strong>Arguments:</strong> None</li>


### PR DESCRIPTION
This was requested by a user because only team or user IDs work here, not board or card IDs, which isn't specified in the docs currently.