### PR TITLE
More Power-Up Examples and Organizations API Docs Update

### DIFF
--- a/app/templates/apis/start-building.html
+++ b/app/templates/apis/start-building.html
@@ -45,8 +45,8 @@
   <p>First, let's define what happens when authentication has finished using success
     and failure callbacks.</p>
 
-<pre>var authenticationSuccess = function() { console.log(Successful authentication); };
-var authenticationFailure = function() { console.log(Failed authentication); };</pre>
+<pre>var authenticationSuccess = function() { console.log('Successful authentication'); };
+var authenticationFailure = function() { console.log('Failed authentication'); };</pre>
 
   <h4>Authenticate and Authorize your user</h4>
   <p>Now let's attempt authentication and authorization in one step.</p>

--- a/app/templates/docs/organization.html
+++ b/app/templates/docs/organization.html
@@ -1310,7 +1310,7 @@
                 <li><code class="docutils literal"><span class="pre">fullName</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idPremOrgsAdmin</span></code></li>
                 <li><code class="docutils literal"><span class="pre">initials</span></code></li>
-                <li><code class="docutils literal"><span class="pre">memberType</span></code></li>
+                <li><code class="docutils literal"><span class="pre">memberType</span></code> - Return values will be <i>normal</i> or <i>ghost</i>. A <i>ghost</i> member is an individual who has been invited to join a board but has not yet created a Trello account.</li>
                 <li><code class="docutils literal"><span class="pre">products</span></code></li>
                 <li><code class="docutils literal"><span class="pre">status</span></code></li>
                 <li><code class="docutils literal"><span class="pre">url</span></code></li>
@@ -1367,10 +1367,8 @@
               <ul>
                 <li><code class="docutils literal"><span class="pre">admins</span></code></li>
                 <li><code class="docutils literal"><span class="pre">all</span></code></li>
-                <li><code class="docutils literal"><span class="pre">none</span></code></li>
-                <li><code class="docutils literal"><span class="pre">normal</span></code></li>
-                <li><code class="docutils literal"><span class="pre">owners</span></code></li>
-              </ul>
+                <li><code class="docutils literal"><span class="pre">normal</span></code> - Returns all members with a <i>memberType</i> of <i>normal</i> (excluding <i>memberType</i>s of <i>ghost</i>.</li>
+                </ul>
             </li>
           </ul>
         </li>

--- a/app/templates/docs/organization.html
+++ b/app/templates/docs/organization.html
@@ -1763,27 +1763,6 @@
             </li>
           </ul>
         </li>
-        <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
-          <ul>
-            <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
-              <ul>
-                <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
-                <li><code class="docutils literal"><span class="pre">bio</span></code></li>
-                <li><code class="docutils literal"><span class="pre">bioData</span></code></li>
-                <li><code class="docutils literal"><span class="pre">confirmed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">fullName</span></code></li>
-                <li><code class="docutils literal"><span class="pre">idPremOrgsAdmin</span></code></li>
-                <li><code class="docutils literal"><span class="pre">initials</span></code></li>
-                <li><code class="docutils literal"><span class="pre">memberType</span></code></li>
-                <li><code class="docutils literal"><span class="pre">products</span></code></li>
-                <li><code class="docutils literal"><span class="pre">status</span></code></li>
-                <li><code class="docutils literal"><span class="pre">url</span></code></li>
-                <li><code class="docutils literal"><span class="pre">username</span></code></li>
-              </ul>
-            </li>
-          </ul>
-        </li>
       </ul>
     </li>
   </ul>
@@ -1808,27 +1787,6 @@
               <ul>
                 <li><code class="docutils literal"><span class="pre">true</span></code></li>
                 <li><code class="docutils literal"><span class="pre">false</span></code></li>
-              </ul>
-            </li>
-          </ul>
-        </li>
-        <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
-          <ul>
-            <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
-              <ul>
-                <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
-                <li><code class="docutils literal"><span class="pre">bio</span></code></li>
-                <li><code class="docutils literal"><span class="pre">bioData</span></code></li>
-                <li><code class="docutils literal"><span class="pre">confirmed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">fullName</span></code></li>
-                <li><code class="docutils literal"><span class="pre">idPremOrgsAdmin</span></code></li>
-                <li><code class="docutils literal"><span class="pre">initials</span></code></li>
-                <li><code class="docutils literal"><span class="pre">memberType</span></code></li>
-                <li><code class="docutils literal"><span class="pre">products</span></code></li>
-                <li><code class="docutils literal"><span class="pre">status</span></code></li>
-                <li><code class="docutils literal"><span class="pre">url</span></code></li>
-                <li><code class="docutils literal"><span class="pre">username</span></code></li>
               </ul>
             </li>
           </ul>

--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -130,8 +130,6 @@ TrelloPowerUp.initialize({
     "member": "556c8537a1928ba745504ad8",
     "permissions": {
       "board": "write",
-      "organization": "write",
-      "card": "write"
     },
     "board": "5834bb5fb7d8021c5b51a8de",
     "command": "board-buttons",

--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -102,10 +102,10 @@ TrelloPowerUp.initialize({
   <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalizationa and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
   <li><strong>board(field1, field2, ...)</strong>
 	Returns a promise with information about the board for the current context.
-	Valid fields include: 'id', 'name', 'url', 'shortLink'</li>
+	Valid fields include: 'id', 'name', 'url', 'shortLink', 'members'</li>
 	<li><strong>list(field1, field2, ...)</strong>
 	Returns a promise with information about the list for the current context
-	Valid fields include: 'id', 'name'</li>
+	Valid fields include: 'id', 'name', 'cards'</li>
 	<li><strong>card(field1, field2, ...)</strong>
 	Returns a promise with information about the card for the current context. The information available is only when a specific card is in context. For instance, this function will return information about a card successfully inside of the capabilities 'attachment-sections' and 'card-badges', but not 'show-settings' nor 'board-buttons'. The latter are not within the context of a single card.
 	Valid fields include: 'id', 'name', 'desc', 'due', 'closed', 'cover', 'attachments', 'members', 'labels', 'url', 'shortLink', 'idList'<br /><br />
@@ -113,6 +113,10 @@ TrelloPowerUp.initialize({
 <pre>t.card('id', 'name', 'url').then(function(promiseResult){console.log(promiseResult)});
 // <- {id:"72hejh3iuruyr87rhiu", name: "Card Name", url: "https://trello.com/c/38UCRu1a/card-name"}</pre>
 	</li>
+  <li><strong>t.lists</strong>
+  Takes same args as <i>t.list</i> but gives back all open lists on the board</li>
+  <li><strong>t.member</strong> Accepted fields: 'id', 'fullName', 'username'. This is an easy way to get information about active members.</li>
+  <li><strong>t.cards</strong> Takes same args as <i>t.card</i> but gives back all open cards on the board.
 	<li><strong>t.closePopup</strong>, <strong>t.closeOverlay</strong>, <strong>t.iframe</strong> can only be called within an appropriate context.</li>
 	<li><strong>t.popup</strong> can only be called within a capability, not currently from an iframe such as an attachment-section. This is due to the relative placement of the popup to an item within the Trello Web Client.</li>
 </ul>
@@ -129,15 +133,23 @@ TrelloPowerUp.initialize({
   "locale":"en-US"
 }</pre>
   <p>Card Capability Options</p>
-  <pre>{
-  "context":{
-    "board":"55db14fd3e104ac8b105bd75",
-    "card":"563b532e4e998440d0d88e62",
-    "command":"card-detail-badges",
-    "plugin":"564ddf493f184b88ea5ddc0e"
+  <pre>
+"{
+  "context": {
+    "member": "556c8537a1928ba745504ad8",
+    "permissions": {
+      "board": "write",
+      "organization": "write",
+      "card": "write"
+    },
+    "board": "5834bb5fb7d8021c5b51a8de",
+    "card": "5858482d9c1c35c230d475ba",
+    "command": "card-buttons",
+    "__insecure_signature": "69eda4985e3fa8c7286cf626-f65bc7b"
   },
-  "locale":"en-US"
-} </pre>
+  "locale": "en-US"
+}"
+  </pre>
   <p>Attachment Sections Options</p>
   <pre>{
   "entries":[

--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -124,14 +124,22 @@ TrelloPowerUp.initialize({
 <h3 id="capability-options">Capability Options</h3>
 <p>Each capability that you include in your initialization will take a reference to the <strong>t</strong> object and a options or context object. This object will include various things depending on the capability.</p>
   <p>Board Capability Options</p>
-  <pre>{
-  "context":{
-    "board":"55db14fd3e105ac84105bd75",
-    "command":"board-buttons",
-    "plugin":"564ddf493f183488ea5ddc0e"
+  <pre>
+"{
+  "context": {
+    "member": "556c8537a1928ba745504ad8",
+    "permissions": {
+      "board": "write",
+      "organization": "write",
+      "card": "write"
+    },
+    "board": "5834bb5fb7d8021c5b51a8de",
+    "command": "board-buttons",
+    "__insecure_signature": "69eda4985e3fa8c7286cf626-f65bc7b"
   },
-  "locale":"en-US"
-}</pre>
+  "locale": "en-US"
+}"
+</pre>
   <p>Card Capability Options</p>
   <pre>
 "{

--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -4,13 +4,17 @@
 	<p>By using this library, your application-specific code can be simplified to the set of <a ui-sref="power-ups.capabilities">capabilities</a> that you wish to expose.
 	The library is hosted here:</p>
 	<a href="https://trello.com/power-ups/power-up.min.js" target="_blank">https://trello.com/power-ups/power-up.min.js</a>
+
 	<a href="https://trello.com/power-ups/power-up.js" target="_blank">https://trello.com/power-ups/power-up.js</a>
 
 	<p>We also provide a CSS file which you should use to automatically achieve a <a ui-sref="power-ups.style">consistent style</a> with Trello:</p>
 	<a href="https://trello.com/power-ups/power-up.css" target="_blank">https://trello.com/power-ups/power-up.css</a>
 
-	<h3>initialize({'[capability-name]':function() {}, ...})</h3>
-	<p>The most important method of the Client Library which is required for all Power-Ups, is the <strong>initialize</strong> method. This method should be called within your <a ui-sref="power-ups.architecture({'#':'index-connector'})">index connector</a>. Initialize accepts only one parameter, a JavaScript object containing any of the <a ui-sref="power-ups.capabilities">capabilities</a> you wish to use in your Power-Up, with the name of the capability as the key, and the function you would like us to call when a capability is executed as the value.</p>
+	<h3 id="initialization">Initialization Methods</h3>
+
+	<p>The most important method of the Client Library which is required for all Power-Ups, is the <strong>initialize</strong> method:</p>
+  <strong>initialize({'[capability-name]':function() {}, ...})</strong>
+  <p>This method should be called within your <a ui-sref="power-ups.architecture({'#':'index-connector'})">index connector</a>. Initialize accepts only one parameter, a JavaScript object containing any of the <a ui-sref="power-ups.capabilities">capabilities</a> you wish to use in your Power-Up, with the name of the capability as the key, and the function you would like us to call when a capability is executed as the value.</p>
 	<pre>TrelloPowerUp.initialize({
   'board-buttons': function(t, options){
     return [{
@@ -28,9 +32,95 @@
     });
   }
 });</pre>
-	<p>Each capability that you include in your initialization will take a reference to the <strong>t</strong> object and a options or context object. This object will include various things depending on the capability.</p>
-	<p>Board Capability Options</p>
-	<pre>{
+	<p>You can find more documentation below for <a ui-sref="power-ups.client-library({'#':'capability-options'})">cability options</a>.</p>
+
+	<h3 id="ux-methods">UX Methods</h3>
+	<ul>
+	<li><strong>render(function renderer)</strong>
+	Define a method that is called by the web client when there are updates, such as a new attachment. Attachment-Sections (and other capabilities) are not re-initialized upon changes to content such as attachments of a card to prevent flashing.
+
+	render is also an important method because we may not know the Member’s locale at time of initialization, but we will know it at render time.
+	</li>
+	<li><strong>popup(options)</strong> Use this method to have Trello display a popup. It will be displayed adjacent to the element in the current context. Pop-ups are designed for lists of capabilities or content that a member is expected to click on.
+	The options object can contain:
+	title
+	callback
+	url
+	items
+	search</li>
+	<li><strong>closePopup()</strong> This method should be used within a popup callback to close the current popup</li>
+	<li><strong>back()</strong> This method should be used within a popup callback to return to the prior popup, if it exists.</li>
+	<li><strong>overlay({url:"./url_to_file.html"})</strong> Place an iframe on top of the Member’s experience</li>
+	<li><strong>closeOverlay()</strong> This method should be used within an overlay to close the existing overlay.</li>
+	<li><strong>boardBar(options)</strong> Used to render an iframe at the bottom of the standard board view.<br />
+	The options object can contain:
+	url
+	args - A list of arguments to be passed to the iframe as query parameters
+	height
+
+  Below is an example of opening a board bar from a board button. When the user clicks the board button labeled "Popup", a board bar with the contents of `board-bar.html` will be displayed.
+<pre>
+TrelloPowerUp.initialize({
+  'board-buttons': function(t, options){
+    return {
+      text: 'Popup',
+      callback: function(t) {
+        text: 'Open Board Bar',
+        callback: function(t){
+          return t.boardBar({
+            url: './board-bar.html',
+            height: 200,
+            args: { example: 1042 }
+          })
+          .then(function(){
+            return t.closePopup();
+          });
+        }
+      }
+    }
+  }
+});
+</pre>
+
+	<li><strong>closeBoardBar()</strong> Used to close the bottom Board Bar</li>
+	<li><strong>authorize(urlWithSecret, options)</strong> Pass a URL to open as a new window for OAuth authentication purposes.</li>
+	NOTE: This must be run within an onclick event from one of your iframes, otherwise the browser popup blocker will be triggered and may break your ability to communicate between your authorization window and the parent Trello window.
+	<li><strong>sizeTo(selector)</strong> - Sizes the current iframe based on the height of the element referenced via your selector.</li>
+	</ul>
+
+	<h3 id="data-methods">Data Methods</h3>
+  <ul>
+	<li><strong>iframe()</strong> Get access to the t object within an iframe</li>
+	<li><strong>set(scope, visibility, name, value)</strong> Used to store some persistent data in Trello's database. The Power-Up provides a scope (organization, board, or card) and the visibility of the data (i.e. whether it's ‘shared’ with everyone that can see the org/board/card or if it's ‘private’) and a string to store. Power-Ups are allowed to store 1K of data for each scope/visibility pair and the current Power-Ups store stringified JSON.
+	Using `t.set` will re-initialize your Power-Up in it’s entirety by re-executing all capabilities.
+  Read more about data storage in the <a ui-sref="power-ups.topics({'#':'data-storage'})">topics section</a>.
+  </li>
+	<li><strong>get(scope, visibility, name, defaultValue)</strong> Used to get all of the stored data for the Power-Up</li>
+	<li><strong>attach({url:URL, name:Name})</strong> Attach a new URL to the card in the current context.</li>
+  <li><strong>signUrl(URL)</strong> Sign a URL for use with <strong>attachment-sections</strong> only.</li>
+  <li><strong>localizeKey(key, data)</strong> Localize a string by key</li>
+  <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalizationa and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
+  <li><strong>board(field1, field2, ...)</strong>
+	Returns a promise with information about the board for the current context.
+	Valid fields include: 'id', 'name', 'url', 'shortLink'</li>
+	<li><strong>list(field1, field2, ...)</strong>
+	Returns a promise with information about the list for the current context
+	Valid fields include: 'id', 'name'</li>
+	<li><strong>card(field1, field2, ...)</strong>
+	Returns a promise with information about the card for the current context. The information available is only when a specific card is in context. For instance, this function will return information about a card successfully inside of the capabilities 'attachment-sections' and 'card-badges', but not 'show-settings' nor 'board-buttons'. The latter are not within the context of a single card.
+	Valid fields include: 'id', 'name', 'desc', 'due', 'closed', 'cover', 'attachments', 'members', 'labels', 'url', 'shortLink', 'idList'<br /><br />
+	Example usage:
+<pre>t.card('id', 'name', 'url').then(function(promiseResult){console.log(promiseResult)});
+// <- {id:"72hejh3iuruyr87rhiu", name: "Card Name", url: "https://trello.com/c/38UCRu1a/card-name"}</pre>
+	</li>
+	<li><strong>t.closePopup</strong>, <strong>t.closeOverlay</strong>, <strong>t.iframe</strong> can only be called within an appropriate context.</li>
+	<li><strong>t.popup</strong> can only be called within a capability, not currently from an iframe such as an attachment-section. This is due to the relative placement of the popup to an item within the Trello Web Client.</li>
+</ul>
+
+<h3 id="capability-options">Capability Options</h3>
+<p>Each capability that you include in your initialization will take a reference to the <strong>t</strong> object and a options or context object. This object will include various things depending on the capability.</p>
+  <p>Board Capability Options</p>
+  <pre>{
   "context":{
     "board":"55db14fd3e105ac84105bd75",
     "command":"board-buttons",
@@ -38,8 +128,8 @@
   },
   "locale":"en-US"
 }</pre>
-	<p>Card Capability Options</p>
-	<pre>{
+  <p>Card Capability Options</p>
+  <pre>{
   "context":{
     "board":"55db14fd3e104ac8b105bd75",
     "card":"563b532e4e998440d0d88e62",
@@ -48,12 +138,12 @@
   },
   "locale":"en-US"
 } </pre>
-	<p>Attachment Sections Options</p>
-	<pre>{
+  <p>Attachment Sections Options</p>
+  <pre>{
   "entries":[
-  	{"id":"56a2467476812315cbbbcbe4","url":"https://example.org/url","name":"https://example.org/url"},
-  	...
-  	{"id":"569e5ab156d89775e853ebb4","url":"https://example.org/url","name":"Attachment Name"}
+    {"id":"56a2467476812315cbbbcbe4","url":"https://example.org/url","name":"https://example.org/url"},
+    ...
+    {"id":"569e5ab156d89775e853ebb4","url":"https://example.org/url","name":"Attachment Name"}
   ],
   "context":{
     "board":"55db14fd3e105ac8b105bd75",
@@ -70,61 +160,6 @@
   },
   "locale":"en-US"
 }</pre>
-	<h3>UX Methods</h3>
-	<ul>
-	<li><strong>render(function renderer)</strong>
-	Define a method that is called by the web client when there are updates, such as a new attachment. Attachment-Sections (and other capabilities) are not re-initialized upon changes to content such as attachments of a card to prevent flashing.
-
-	render is also an important method because we may not know the Member’s locale at time of initialization, but we will know it at render time.
-	</li>
-	<li><strong>popup(options)</strong> Use this method to have Trello display a popup. It will be displayed adjacent to the element in the current context. Pop-ups are designed for lists of capabilities or content that a member is expected to click on.
-	The options object can contain:
-	title
-	callback
-	url
-	items
-	search</li>
-	<li><strong>closePopup()</strong> This method should be used within a popup callback to close the current popup</li>
-	<li><strong>back()</strong> This method should be used within a popup callback to return to the prior popup, if it exists.</li>
-	<li><strong>overlay({url:’’})</strong> Place an iframe on top of the Member’s experience</li>
-	<li><strong>closeOverlay()</strong> This method should be used within an overlay to close the existing overlay.</li>
-	<li><strong>boardBar(options)</strong> Used to render an iframe that is visible at the bottom of the standard board view. This option is currently under development.</li>
-	The options object can contain:
-	url
-	args - A list of arguments to be passed to the iframe as query parameters
-	height
-	<li><strong>closeBoardBar()</strong> Used to close the bottom Board Bar</li>
-	<li><strong>authorize(urlWithSecret, options)</strong> Pass a URL to open as a new window for OAuth authentication purposes.</li>
-	NOTE: This must be run within an onclick event from one of your iframes, otherwise the browser popup blocker will be triggered and may break your ability to communicate between your authorization window and the parent Trello window.
-	<li><strong>sizeTo(selector)</strong> - Sizes the current iframe based on the height of the element referenced via your selector.</li>
-	</ul>
-
-	<h3>Data Methods</h3>
-	<ul>
-	<li><strong>iframe()</strong> Get access to the t object within an iframe</li>
-	<li><strong>set(scope, visibility, name, value)</strong> Used to store some persistent data in Trello's database. The Power-Up provides a scope (organization,board or card) and the visibility of the data (i.e. whether it's ‘shared’ with everyone that can see the org/board/card or if it's ‘private’) and a string to store. (Power-Ups are allowed to store 1K of data for each scope/visibility pair … the current Power-Ups store stringified JSON)
-
-	Using t.set will re-initialize your Power-Up in it’s entirety by re-executing all capabilities.</li>
-	<li><strong>get(scope, visibility, name, defaultValue)</strong> Used to get all of the stored data for the Power-Up</li>
-	<li><strong>attach({url:URL, name:Name})</strong> Attach a new URL to the card in the current context.</li>
-	<li><strong>signUrl(URL)</strong> Sign a URL for use with <strong>attachment-sections</strong> only.</li>
-	<li><strong>localizeKey(key, data)</strong> Localize a string by key</li>
-	<li><strong>localizeKeys(keys)</strong> Localize an list of strings or objects</li>
-	<li><strong>board([requestedField1],[requestedField2],[…])</strong> Returns a promise with information about the board for the current context
-	Valid fields include: 'id', 'name', 'url', 'shortLink'</li>
-	<li><strong>list([requestedField1],[requestedField2],[…])</strong> Returns a promise with information about the list for the current context
-	Valid fields include: 'id', 'name'</li>
-	<li><strong>card([requestedField1],[requestedField2],[…])</strong> Returns a promise with information about the card for the current context
-	Valid fields include: 'id', 'name', 'desc', 'due', 'cover', 'attachments', 'members', 'labels', 'url', 'shortLink'</li>
-	</ul>
-	<p>
-	<li><strong>t.closePopup</strong>, <strong>t.closeOverlay</strong>, <strong>t.iframe</strong> can only be called within an appropriate context.
-	</p>
-	<p>
-	<li><strong>t.popup</strong> can only be called within a capability, not currently from an iframe such as an attachment-section. This is due to the relative placement of the popup to an item within the Trello Web Client.</li>
-	</p>
-
-
 
 
 </div>

--- a/app/templates/power-ups/topics.html
+++ b/app/templates/power-ups/topics.html
@@ -126,7 +126,7 @@ if (window.opener && typeof window.opener.authorize === 'function') {
 setTimeout(function(){ window.close(); }, 1000);
   </pre>
 
-  <h3>Data Storage</h3>
+  <h3 id="data-storage">Data Storage</h3>
   <p>There are various scopes that can be used to store data. These scopes are determined by the visibility level, and the entity
     it is attached to.</p>
   <table>
@@ -172,7 +172,7 @@ setTimeout(function(){ window.close(); }, 1000);
   <p>Your Power-Up should respond within 1 second to all capability methods. If your method takes more than 1 second to complete,
     we will consider the callback as failed.</p>
 
-  <h3>Internationalization</h3>
+  <h3 id="internationalization">Internationalization</h3>
   <p>Trello Power-Ups were designed with Internationalization in mind. When creating a plugin or iframe, you can optionally pass
     in the options argument one of the following:</p>
   <p>localization object</p>


### PR DESCRIPTION
All of the changes to the [`app/templates/docs/organization.html`](https://github.com/trello/api-docs/compare/bentley/updating-examples-and-documentation?expand=1#diff-93f85936b344cfcf2e8a8485bf04f33c) documentation are from [this support ticket](https://trello.com/c/FxTXCWZ4/92-organizations-orgid-memberships-endpoint-question). We use the field name `memberType` for two separate concerns. Additionally, I found that a few of the arguments for the `memberships` were not valid.

On the Power-Ups, I have added a few code examples from https://gomix.com/#!/project/rune-friend as I'm reading through it.