### PR TITLE
Remove /power-up-preview option for Power-Up testing

### DIFF
--- a/app/templates/power-ups/intro.html
+++ b/app/templates/power-ups/intro.html
@@ -15,22 +15,11 @@
   </div>
 
   <h3>Getting Started</h3>
-  <p>Interested in building your own Power-Up? First, clone/download our samples above, or get started by building your own <a ui-sref="power-ups.architecture({'#':'manifest'})">manifest and index connector</a>. Once you've got something ready and hosted via HTTPS, there are two ways to hook up your Power-Up.</p>
-  <ul>
-    <li>
-      <strong>Local Development Only</strong>
-      <p>Visit <a href="https://trello.com/power-up-preview">https://trello.com/power-up-preview</a> and enter an HTTPS-based manifest URL. This will allow you to see and enable your Power-Up only for your current browser and member. Other members of your team won't be able to see your Power-Up, and you will see your Power-Up on all boards belonging to Teams that you have access to.</p>
-    </li>
-    <li>
-      <strong>Team Development</strong>
-      <p>You can start developing a Power-Up for your Team right now by creating a new Power-Up. Click below to get started. We'll need your Power-Up's Name and an HTTPS based manifest to get you setup.</p>
-      <a href="https://trello.com/power-ups/admin" target="_blank" ><button class="mod-primary">Create a Power-Up</button></a>
-    </li>
+  <p>Interested in building your own Power-Up? First, clone/download our samples above, or get started by building your own <a ui-sref="power-ups.architecture({'#':'manifest'})">manifest and index connector</a>. Once you've got something ready and hosted via HTTPS, you'll just need a Trello team for which you want your Power-Up available.</p>
 
-  </ul>
-
-
+  <p>You will need to be a team admin for the Trello team you want to add your Power-Up to. It doesn't matter whether the team is free or paid. Click below to get started. We'll need your Power-Up's Name and an HTTPS based manifest to get you setup.</p>
+  <a href="https://trello.com/power-ups/admin" target="_blank" ><button class="mod-primary">Create a Power-Up</button></a>
+  
   <h3>Looking for more help or clarifications?</h3>
   <p>Already got access, have read the documentation, and are looking for more help or clarification? We are trying out holding office hours for Power-Up development over video chat. To sign up for an office hours appointment, please select from the available slots on this <a href="https://calendar.google.com/calendar/selfsched?sstoken=UU5DczNLUkNIbk5ifGRlZmF1bHR8YzJmZWM4YWM0NTgxMTE1NmRmMzgxNzMwODRjYzEwZGU" target="_blank">calendar</a>.</p>
-
 </div>


### PR DESCRIPTION
The `/power-up-preview` page worked by inserting the manifest location into local storage, and then using that in place of the Package Tracker Power-Up. That can easily lead to confusion. The `/power-ups/admin` approach is much more robust.