### PR TITLE
Better Documenting dateLastActivity Subtleties

### DIFF
--- a/app/templates/docs/card.html
+++ b/app/templates/docs/card.html
@@ -280,7 +280,7 @@
             <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code></li>
+                <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code> - The datetime of the last activity on the card. <b>Note:</b> There are activities that update <i>dateLastActivity</i> that do not create a corresponding action. For instance, updating the <i>name</i> field of a checklist item on a card does not create an action but does update the card and board's <i>dateLastActivity</i> value.</li>
                 <li><code class="docutils literal"><span class="pre">dateLastView</span></code></li>
                 <li><code class="docutils literal"><span class="pre">desc</span></code></li>
                 <li><code class="docutils literal"><span class="pre">descData</span></code></li>
@@ -373,7 +373,7 @@
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code></li>
+                <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code> - The datetime of the last activity on the card. <b>Note:</b> There are activities that update <i>dateLastActivity</i> that do not create a corresponding action. For instance, updating the <i>name</i> field of a checklist item on a card does not create an action but does update the card and board's <i>dateLastActivity</i> value.</li>
                 <li><code class="docutils literal"><span class="pre">desc</span></code></li>
                 <li><code class="docutils literal"><span class="pre">descData</span></code></li>
                 <li><code class="docutils literal"><span class="pre">due</span></code></li>


### PR DESCRIPTION
There has been some confusion when the most recent Action's date doesn't match a board or card's dateLastActivity field. There's even a popular blog post about it: https://blog.clarkrasmussen.com/2014/05/15/trello-api-and-datelastactivity/ So I wanted to add a few words about it in the docs.

In the future these should be linked together a bit more so the docs aren't full of copy-pasta text like this.

Relevant Help Scout ticket: https://trello.com/c/H2CC6hEI/111-update-datelastactivity-actions-difference