### PR TITLE
Removing Pinned Filter On Boards

### DIFF
--- a/app/templates/docs/board.html
+++ b/app/templates/docs/board.html
@@ -612,7 +612,6 @@
                 <li><code class="docutils literal"><span class="pre">labelNames</span></code></li>
                 <li><code class="docutils literal"><span class="pre">memberships</span></code></li>
                 <li><code class="docutils literal"><span class="pre">name</span></code></li>
-                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
                 <li><code class="docutils literal"><span class="pre">powerUps</span></code></li>
                 <li><code class="docutils literal"><span class="pre">prefs</span></code></li>
                 <li><code class="docutils literal"><span class="pre">shortLink</span></code></li>
@@ -673,7 +672,6 @@
                 <li><code class="docutils literal"><span class="pre">labelNames</span></code></li>
                 <li><code class="docutils literal"><span class="pre">memberships</span></code></li>
                 <li><code class="docutils literal"><span class="pre">name</span></code></li>
-                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
                 <li><code class="docutils literal"><span class="pre">powerUps</span></code></li>
                 <li><code class="docutils literal"><span class="pre">prefs</span></code></li>
                 <li><code class="docutils literal"><span class="pre">shortLink</span></code></li>

--- a/app/templates/docs/board.html
+++ b/app/templates/docs/board.html
@@ -612,6 +612,7 @@
                 <li><code class="docutils literal"><span class="pre">labelNames</span></code></li>
                 <li><code class="docutils literal"><span class="pre">memberships</span></code></li>
                 <li><code class="docutils literal"><span class="pre">name</span></code></li>
+                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
                 <li><code class="docutils literal"><span class="pre">powerUps</span></code></li>
                 <li><code class="docutils literal"><span class="pre">prefs</span></code></li>
                 <li><code class="docutils literal"><span class="pre">shortLink</span></code></li>
@@ -672,6 +673,7 @@
                 <li><code class="docutils literal"><span class="pre">labelNames</span></code></li>
                 <li><code class="docutils literal"><span class="pre">memberships</span></code></li>
                 <li><code class="docutils literal"><span class="pre">name</span></code></li>
+                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
                 <li><code class="docutils literal"><span class="pre">powerUps</span></code></li>
                 <li><code class="docutils literal"><span class="pre">prefs</span></code></li>
                 <li><code class="docutils literal"><span class="pre">shortLink</span></code></li>

--- a/app/templates/docs/organization.html
+++ b/app/templates/docs/organization.html
@@ -247,12 +247,12 @@
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">none</span></code></li>
             <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
               <ul>
-                <li><code class="docutils literal"><span class="pre">open</span></code> Returns all boards that are open.</li>
-                <li><code class="docutils literal"><span class="pre">closed</span></code> Returns all boards that have been closed.</li>
-                <li><code class="docutils literal"><span class="pre">members</span></code> Returns all boards that have visibility set to Private.</li>
-                <li><code class="docutils literal"><span class="pre">organization</span></code> Returns all boards that have visibility set to Team.</li>
-                <li><code class="docutils literal"><span class="pre">public</span></code> Returns all boards that have visibility set to Public.</li>
-                <li><code class="docutils literal"><span class="pre">starred</span></code> Returns all boards that have been starred.</li>
+                <li><code class="docutils literal"><span class="pre">open</span></code> - Returns all boards that are open.</li>
+                <li><code class="docutils literal"><span class="pre">closed</span></code> - Returns all boards that have been closed.</li>
+                <li><code class="docutils literal"><span class="pre">members</span></code> - Returns all boards that have visibility set to Private.</li>
+                <li><code class="docutils literal"><span class="pre">organization</span></code> - Returns all boards that have visibility set to Team.</li>
+                <li><code class="docutils literal"><span class="pre">public</span></code> - Returns all boards that have visibility set to Public.</li>
+                <li><code class="docutils literal"><span class="pre">starred</span></code> - Returns all boards that have been starred.</li>
               </ul>
             </li>
           </ul>
@@ -940,14 +940,12 @@
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
             <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
               <ul>
-                <li><code class="docutils literal"><span class="pre">closed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">members</span></code></li>
-                <li><code class="docutils literal"><span class="pre">open</span></code></li>
-                <li><code class="docutils literal"><span class="pre">organization</span></code></li>
-                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
-                <li><code class="docutils literal"><span class="pre">public</span></code></li>
-                <li><code class="docutils literal"><span class="pre">starred</span></code></li>
-                <li><code class="docutils literal"><span class="pre">unpinned</span></code></li>
+                <li><code class="docutils literal"><span class="pre">open</span></code> - Returns all boards that are open.</li>
+                <li><code class="docutils literal"><span class="pre">closed</span></code> - Returns all boards that have been closed.</li>
+                <li><code class="docutils literal"><span class="pre">members</span></code> - Returns all boards that have visibility set to Private.</li>
+                <li><code class="docutils literal"><span class="pre">organization</span></code> - Returns all boards that have visibility set to Team.</li>
+                <li><code class="docutils literal"><span class="pre">public</span></code> - Returns all boards that have visibility set to Public.</li>
+                <li><code class="docutils literal"><span class="pre">starred</span></code> - Returns all boards that have been starred.</li>
               </ul>
             </li>
           </ul>
@@ -1236,14 +1234,12 @@
           <ul>
             <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
               <ul>
-                <li><code class="docutils literal"><span class="pre">closed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">members</span></code></li>
-                <li><code class="docutils literal"><span class="pre">open</span></code></li>
-                <li><code class="docutils literal"><span class="pre">organization</span></code></li>
-                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
-                <li><code class="docutils literal"><span class="pre">public</span></code></li>
-                <li><code class="docutils literal"><span class="pre">starred</span></code></li>
-                <li><code class="docutils literal"><span class="pre">unpinned</span></code></li>
+                <li><code class="docutils literal"><span class="pre">open</span></code> - Returns all boards that are open.</li>
+                <li><code class="docutils literal"><span class="pre">closed</span></code> - Returns all boards that have been closed.</li>
+                <li><code class="docutils literal"><span class="pre">members</span></code> - Returns all boards that have visibility set to Private.</li>
+                <li><code class="docutils literal"><span class="pre">organization</span></code> - Returns all boards that have visibility set to Team.</li>
+                <li><code class="docutils literal"><span class="pre">public</span></code> - Returns all boards that have visibility set to Public.</li>
+                <li><code class="docutils literal"><span class="pre">starred</span></code> - Returns all boards that have been starred.</li>
               </ul>
             </li>
           </ul>

--- a/app/templates/docs/organization.html
+++ b/app/templates/docs/organization.html
@@ -247,14 +247,12 @@
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">none</span></code></li>
             <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
               <ul>
-                <li><code class="docutils literal"><span class="pre">closed</span></code></li>
-                <li><code class="docutils literal"><span class="pre">members</span></code></li>
-                <li><code class="docutils literal"><span class="pre">open</span></code></li>
-                <li><code class="docutils literal"><span class="pre">organization</span></code></li>
-                <li><code class="docutils literal"><span class="pre">pinned</span></code></li>
-                <li><code class="docutils literal"><span class="pre">public</span></code></li>
-                <li><code class="docutils literal"><span class="pre">starred</span></code></li>
-                <li><code class="docutils literal"><span class="pre">unpinned</span></code></li>
+                <li><code class="docutils literal"><span class="pre">open</span></code> Returns all boards that are open.</li>
+                <li><code class="docutils literal"><span class="pre">closed</span></code> Returns all boards that have been closed.</li>
+                <li><code class="docutils literal"><span class="pre">members</span></code> Returns all boards that have visibility set to Private.</li>
+                <li><code class="docutils literal"><span class="pre">organization</span></code> Returns all boards that have visibility set to Team.</li>
+                <li><code class="docutils literal"><span class="pre">public</span></code> Returns all boards that have visibility set to Public.</li>
+                <li><code class="docutils literal"><span class="pre">starred</span></code> Returns all boards that have been starred.</li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
## Purpose
I believe pinning boards is a very old feature that is now deprecated. Updating board filters to reflect the deprecation and adding a bit of clarifying text around the other filters.