### PR TITLE
Fix typo: "Internationalization" (vs "internationalizationa")

### DIFF
--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -99,7 +99,7 @@ TrelloPowerUp.initialize({
 	<li><strong>attach({url:URL, name:Name})</strong> Attach a new URL to the card in the current context.</li>
   <li><strong>signUrl(URL)</strong> Sign a URL for use with <strong>attachment-sections</strong> only.</li>
   <li><strong>localizeKey(key, data)</strong> Localize a string by key</li>
-  <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalizationa and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
+  <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalization and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
   <li><strong>board(field1, field2, ...)</strong>
 	Returns a promise with information about the board for the current context.
 	Valid fields include: 'id', 'name', 'url', 'shortLink', 'members'</li>


### PR DESCRIPTION
## Description
Fixes a typo on `client-library.html` in the Power-ups documentation. 

## Issues Addressed
Submitting PR without a related issue due to the its minor nature. 

## Screenshots

#### Before (live on the current site)

> ![image](https://cloud.githubusercontent.com/assets/2148318/24174372/a69f3766-0e66-11e7-91fb-3480f8b27f56.png)

#### After (my local build)

> ![image](https://cloud.githubusercontent.com/assets/2148318/24174387/b6425fd6-0e66-11e7-93fe-7bcba86c1395.png)