### PR TITLE
Add pointer to Card Snooze Glitch Project

### DIFF
--- a/app/templates/power-ups/intro.html
+++ b/app/templates/power-ups/intro.html
@@ -8,9 +8,10 @@
   <p>Power-Ups gain read-only access to member information as members interact with the Power-Up. Power-Ups can make Attachments to Cards and can store Power-Up specific data, but are restricted from making other changes.</p>
 
   <h3>Power-Up Samples</h3>
-  <p>Trello has built two sample Power-Ups that you can use to get started developing right away. These samples demonstrate the capabilities of the platform and should help you to get started.</p>
+  <p>Trello has built some sample Power-Ups that you can use to get started developing right away. These samples demonstrate the capabilities of the platform and should help you to get started.</p>
   <div>
     <a href="https://glitch.com/edit/#!/trello-power-up" target="_blank" rel="noopener noreferrer"><button class="mod-primary">Remix the Glitch Sample Project</button></a>
+    <a href="https://glitch.com/edit/#!/trellocardsnooze" target="_blank" rel="noopener noreferrer"><button class="mod-primary">Remix the Card Snooze Power-Up</button></a>
     <a href="https://github.com/trello/power-up-template" target="_blank" rel="noopener noreferrer"><button class="mod-primary">Clone the GitHub Pages Sample</button></a>
   </div>
 


### PR DESCRIPTION
## Description

Adds a button in the Power-Up Samples section that links to the Card Snooze Glitch project, as another great starting point for Power-Up development.