### PR TITLE
Add syntax highlighting to Power-Up docs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Trello Developers">
 
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/highlight.js/9.10.0/styles/github-gist.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/github-gist.min.css">
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.0/angular-material.min.css">
   <link rel="stylesheet" href="/styles/app.min.css">
 
@@ -29,8 +29,9 @@
     } catch (e) {}
   </script>
 
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/languages/go.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/languages/javascript.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/languages/json.min.js"></script>
 
   <base href="/">
 </head>

--- a/app/index.html
+++ b/app/index.html
@@ -17,6 +17,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Trello Developers">
 
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/highlight.js/9.10.0/styles/github-gist.min.css">
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.0/angular-material.min.css">
   <link rel="stylesheet" href="/styles/app.min.css">
 
@@ -27,6 +28,9 @@
       Typekit.load();
     } catch (e) {}
   </script>
+
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/languages/go.min.js"></script>
 
   <base href="/">
 </head>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -170,6 +170,12 @@ app.run(['$rootScope', '$location', '$window', '$anchorScroll', function($rootSc
   $rootScope
     .$on('$stateChangeSuccess',
       function(event){
+        setTimeout(function(){
+          $('pre code').each(function(i, block) {
+            hljs.highlightBlock(block);
+          });
+        }, 300);
+
         $anchorScroll();
         if( $window.ga ) {
           $window.ga('send', 'pageview', { page: $location.path() });

--- a/app/templates/power-ups/architecture.html
+++ b/app/templates/power-ups/architecture.html
@@ -11,7 +11,7 @@
   <h3 id="manifest">manifest.json</h3>
   <p>We load your Manifest each time a member tries to add or manage their Power-Ups, or every time your Power-Up is activated by a Member loading a board. Your manifest determines which <a ui-sref="power-ups.capabilities">capabilities</a> we attempt to execute from your Power-Up.</p>
   <p>We require <strong>name</strong>, <strong>details</strong>, <strong>icon</strong>, <strong>author</strong>, <strong>capabilities</strong>, and <strong>connectors</strong> parameters as shown in this sample:</p>
-	<pre>{
+	<pre><code class="json">{
   "name": "Power-Up Name",
   "details": "The [Power-Up Name](https://example.org) is awesome because it can...",
   "icon": {
@@ -26,7 +26,7 @@
       "url": "./"
     }
   }
-}</pre>
+}</code></pre>
 	<p>Your manifest location will be one of the things required as part of setting up your Power-Up. You will not be able to change your manifest location after it is set. Additionally, all files hosted on your servers must be served over HTTPS.</p>
 	<p>The URL referenced within <strong>connectors.iframe.url</strong> is relative to the path of your manifest.json file.</p>
 
@@ -34,7 +34,7 @@
 	<p>Once a user has added your Power-Up to one of their boards, each time the board is loaded, we will load your specified connector URL in an iframe. It is this page that we will be using to expose functionality, and to invoke capabilities.</p>
   <p>Your index connector should use a &lt;script&gt; tag to include the Trello hosted <a ui-sref="power-ups.client-library">Power-Up library</a>.</p>
   <p>Your index connector is also responsible for initializing your Power-Up and providing the callback functions for each of your supported capabilities.</p>
-  <pre>TrelloPowerUp.initialize({
+  <pre><code class="javascript">TrelloPowerUp.initialize({
   'board-buttons': function(t, options){
     return [{
     icon: './images/icon-white.svg',
@@ -50,19 +50,19 @@
       height: 184
     });
   }
-});</pre>
+});</code></pre>
 <h3>Additional iframes</h3>
 <p>Your Power-Up will often need to show additional iframes, such as when using <strong>t.overlay()</strong> or <strong>t.popup()</strong>. These pages should also include the Power-Up client library script in order to enable communications with Trello.</p>
 <p>To initialize the Power-Up from an iframe other than your connector you should call:</p>
-<pre>var t = TrelloPowerUp.iframe();</pre>
+<pre><code class="javascript">var t = TrelloPowerUp.iframe();</code></pre>
 <p>After you have initialzed the Power-Up in your iframe, you can use all of the <strong>t</strong> helper methods such as <strong>t.render()</strong>, <strong>t.sizeTo()</strong>, <strong>t.get()</strong>, etc.</p>
 
 
 <h3>Examined Power-Up - Appear.in</h3>
 <p>
-To understand the general architecture of Capabilities, we will use a sample Appear.in plugin to demonstrate one of the simplest Capabilities, “board-buttons”. This Capability adds a button to the top of the board. 
+To understand the general architecture of Capabilities, we will use a sample Appear.in plugin to demonstrate one of the simplest Capabilities, “board-buttons”. This Capability adds a button to the top of the board.
 </p>
-<pre>var AppearIn = require('appearin-sdk');
+<pre><code class="javascript">var AppearIn = require('appearin-sdk');
 
 var appearin = new AppearIn();
 var roomUrl = function(path) {
@@ -77,16 +77,16 @@ TrelloPowerUp.initialize({
   // a reference to the board context for any potential buttons
   'board-buttons': function(t, board) {
 
-    // We verify via the Appear.in SDK that the member is 
+    // We verify via the Appear.in SDK that the member is
     // capable of using Appear.in. If not, show no button
     if(!appearin.isWebRtcCompatible()) {
       return [];
     }
 
 
-    // We create a button by specifying that when the board 
-    // details promise has been resolved, we return an object 
-    // with the contents of the button once the board details 
+    // We create a button by specifying that when the board
+    // details promise has been resolved, we return an object
+    // with the contents of the button once the board details
     // have been loaded
     return t.board()
     .then(function(board){
@@ -101,12 +101,12 @@ TrelloPowerUp.initialize({
       ]
     })
   }
-})</pre>
+})</code></pre>
 
 <h3>Examined Power-Up - Dropbox</h3>
 <p>Dropbox is a more complex Power-Up. Our Dropbox Power-Up takes advantage of attachment-sections, attachment-thumbnail, format-url, and card-buttons.
 </p>
-<pre>
+<pre><code class="javascript">
 var api = require('src/api');
 var dataForUrl = require('src/data-for-url');
 var dropboxButton = require('src/dropbox-button');
@@ -208,5 +208,4 @@ TrelloPowerUp.initialize({
       callback: dropboxButton
     }]
   }
-});
-</pre>
+});</code></pre>

--- a/app/templates/power-ups/capabilities.html
+++ b/app/templates/power-ups/capabilities.html
@@ -91,17 +91,15 @@
   </div>
   <p>You are expected to return a list of of buttons.</p>
   <h4>Static URL Example</h4>
-  <pre>'board-buttons': function(t, board) {
-  return [
-    {
-      icon: './images/icon.svg',
-      text: "Button Text",
-      url: 'https://developers.trello.com/'
-    }
-  ];
-}</pre>
+  <pre><code class="javascript">'board-buttons': function(t, board) {
+  return [{
+    icon: './images/icon.svg',
+    text: "Button Text",
+    url: 'https://developers.trello.com/'
+  }];
+}</code></pre>
   <h4>Callback Example</h4>
-  <pre>'card-buttons': function(t, options){
+  <pre><code class="javascript">'card-buttons': function(t, options){
   return [{
     icon: './images/icon.svg',
     text: 'Button Text',
@@ -112,7 +110,7 @@
       });
     }
   }];
-}</pre>
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -140,18 +138,16 @@
   <hr/>
   <h3><span id="card-badges">card-badges</span> &amp; <span id="card-detail-badges">card-detail-badges</span></h3>
   <h4>Example</h4>
-  <pre>'card-badges': function(t, card) {
-  return [
-    {
-      icon: './images/icon.svg',
-      text: '3'
-    }
-  ];
-}</pre>
+  <pre><code class="javascript">'card-badges': function(t, card) {
+  return [{
+    icon: './images/icon.svg',
+    text: '3'
+  }];
+}</code></pre>
   <h4>Dynamic Example</h4>
-  <pre>'card-badges': function(t, card) {
+  <pre><code class="javascript">'card-badges': function(t, card) {
   return {
-    dynamic: function(){
+    dynamic: function() {
       return {
         title: 'Detail Badge', // for detail badges only
         text: 'Dynamic ' + (Math.random() * 100).toFixed(0).toString(),
@@ -161,7 +157,7 @@
       }
     }
   }
-}</pre>
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -185,7 +181,7 @@
     <li>
       <strong>refresh (optional)</strong>
       <div>The number of seconds between refreshes. The system will ignore a refresh of less than 10 seconds. In order to use refresh, the object to be returned should instead look like:</div>
-      <pre>{dynamic: callbackFunction(t, context)}</pre>
+      <pre><code class="javascript">{ dynamic: callbackFunction(t, context) }</code></pre>
     </li>
   </ul>
   <p>By returning an object with the property <strong>dynamic</strong> specified as a function that returns these parameters, your card badge will be regenerated based on your supplied refresh rate.</p>
@@ -193,20 +189,17 @@
   <h3 id="attachment-sections">attachment-sections</h3>
   <img src="/images/content/sample-attachment-section.png" alt="Attachment Sections" />
   <h4>Example</h4>
-  <pre>'attachment-sections': function(t, options) {
-  return [
-    {
-      icon: './images/icon.svg',
-      title: "Attachment Section",
-      claimed: [arrayOfClaimedAttachments],
-      content: {
-        type: 'iframe',
-        url: t.signUrl('./attachment-section.html')
-      }
-
+  <pre><code class="javascript">'attachment-sections': function(t, options) {
+  return [{
+    icon: './images/icon.svg',
+    title: "Attachment Section",
+    claimed: [arrayOfClaimedAttachments],
+    content: {
+      type: 'iframe',
+      url: t.signUrl('./attachment-section.html')
     }
-  ];
-}</pre>
+  }];
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -238,8 +231,8 @@
   <h3 id="attachment-thumbnail">attachment-thumbnail</h3>
   <img src="/images/content/sample-attachment.png" alt="Attachment Thumbnail" />
   <h4>Example</h4>
-  <pre>'attachment-thumbnail': function(t, attachment) {
-  if(attachment.url == "https://developers.trello.com/") {
+  <pre><code class="javascript">'attachment-thumbnail': function(t, attachment) {
+  if (attachment.url == "https://developers.trello.com/") {
     return {
       title: "Trello Developer Site",
       url: "https://developers.trello.com/",
@@ -254,10 +247,9 @@
       }
     };
   } else {
-          throw t.NotHandled("Not a handled URL");
+    throw t.NotHandled("Not a handled URL");
   }
-},
-</pre>
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -301,17 +293,16 @@
   <h3 id="format-url">format-url</h3>
   <img src="/images/content/sample-format-url.png" alt="Formatted URL Rendering" />
   <h4>Example</h4>
-  <pre>'format-url': function(t, options) {
-  if(options.url.length > 20) {
+  <pre><code class="javascript">'format-url': function(t, options) {
+  if (options.url.length > 20) {
     return {
       icon: './images/trello-icon.png',
       text: options.url
-
     };
   } else {
     throw t.NotHandled("Not a handled URL");
   }
-},</pre>
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -338,14 +329,14 @@
   <hr/>
   <h3 id="card-from-url">card-from-url</h3>
   <h4>Example</h4>
-  <pre>'card-from-url': function(t, options) {
+  <pre><code class="javascript">'card-from-url': function(t, options) {
   // return a name, and optionally a description
   // based on options.url
   return {
     name: 'Suitable name based on options.url',
     desc: 'Suitable description based on options.url'
   };
-},</pre>
+}</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -362,13 +353,13 @@
   <p>When a user goes to edit your Power-Up's settings by clicking on the gear icon next to your Power-Up's listing, Trello automatically provides a drop-down list with options. The `show-settings` capability will be invoked when they select "Edit Power-Up Settings" from the list.</p>
   <img src="/images/content/sample-popup.png" alt="Show Settings Popup" />
   <h4>Example</h4>
-  <pre>'show-settings': function(t, options) {
+  <pre><code class="javascript">'show-settings': function(t, options) {
   return t.popup({
     title: "Power-Up Settings",
     url: 'settings.html',
     height: 250
   });
-}</pre>
+}</code></pre>
   <p>If you have data stored in the private scope via the client library's <a href="https://developers.trello.com/power-ups/topics#data-storage">`t.set` data method</a>, the drop-down list will also include an option to "Remove Personal Settings". If a user clicks this option, Trello will remove all data stored in the private scope.</p>
   <img src="/images/content/sample-remove-personal-settings.png" alt="Show Settings Popup" />
   <hr/>
@@ -376,11 +367,11 @@
   <p>Used to determine whether a user has authorized using your Power-Up. You should return a promise that resolves to the object with a property 'authorized' that is either true or false. You may also return the object synchronously if you know the answer synchronously.</p>
   <p>If the 'authorization-status' capability resolves to false, when the user views your Power-Up's settings, they will be prompted with an option to "Authorize Account" which will invoke your <a href="#show-authorization">'show-authorization'</a> capability.</p>
   <h4>Example</h4>
-  <pre>'authorization-status': function(t) {
-    return new TrelloPowerUp.Promise((resolve) => 
+  <pre><code class="javascript">'authorization-status': function(t) {
+    return new TrelloPowerUp.Promise((resolve) =>
       resolve({ authorized: false })
     )
-  }</pre>
+  }</code></pre>
   <h4>Fields</h4>
   <ul>
     <li>
@@ -393,12 +384,12 @@
   <p>Used to determine what to show the user when the `authorization-status` capability returns false.</p>
   <img src="/images/content/sample-show-authorization.png" alt="Show Authorizations" />
   <h4>Example</h4>
-  <pre>'show-authorization': function(t) {
+  <pre><code class="javascript">'show-authorization': function(t) {
     t.popup({
       title: 'My Auth Popup',
       url: 'authorize.html',
       height: 140,
     })
-  }</pre>
+  }</code></pre>
   <p>No fields need to be returned with this capability. Standard behavior is to open a popup as shown in the example above.</p>
 </div>

--- a/app/templates/power-ups/client-library.html
+++ b/app/templates/power-ups/client-library.html
@@ -1,16 +1,19 @@
 <div class="app-content">
   <h2>Power-Up Client Library</h2>
-  <p>We provide and host a Javascript library for all Power-Ups. This Library gives you access to a standardized communication structure between your Power-Up and the Trello web experience. </p>
-  <p>By using this library, your application-specific code can be simplified to the set of <a ui-sref="power-ups.capabilities">capabilities</a> that you wish to expose. The library is hosted here:</p>
+  <p>We provide and host a Javascript library for all Power-Ups. This Library gives you access to a standardized communication
+    structure between your Power-Up and the Trello web experience. </p>
+  <p>By using this library, your application-specific code can be simplified to the set of <a ui-sref="power-ups.capabilities">capabilities</a>    that you wish to expose. The library is hosted here:</p>
   <a href="https://trello.com/power-ups/power-up.min.js" target="_blank">https://trello.com/power-ups/power-up.min.js</a>
   <a href="https://trello.com/power-ups/power-up.js" target="_blank">https://trello.com/power-ups/power-up.js</a>
-  <p>We also provide a CSS file which you should use to automatically achieve a <a ui-sref="power-ups.style">consistent style</a> with Trello:</p>
+  <p>We also provide a CSS file which you should use to automatically achieve a <a ui-sref="power-ups.style">consistent style</a>    with Trello:</p>
   <a href="https://trello.com/power-ups/power-up.css" target="_blank">https://trello.com/power-ups/power-up.css</a>
   <h3 id="initialization">Initialization Methods</h3>
-  <p>The most important method of the Client Library which is required for all Power-Ups, is the <strong>initialize</strong> method:</p>
+  <p>The most important method of the Client Library which is required for all Power-Ups, is the <strong>initialize</strong>    method:</p>
   <strong>initialize({'[capability-name]':function() {}, ...})</strong>
-  <p>This method should be called within your <a ui-sref="power-ups.architecture({'#':'index-connector'})">index connector</a>. Initialize accepts only one parameter, a JavaScript object containing any of the <a ui-sref="power-ups.capabilities">capabilities</a> you wish to use in your Power-Up, with the name of the capability as the key, and the function you would like us to call when a capability is executed as the value.</p>
-  <pre>TrelloPowerUp.initialize({
+  <p>This method should be called within your <a ui-sref="power-ups.architecture({'#':'index-connector'})">index connector</a>.
+    Initialize accepts only one parameter, a JavaScript object containing any of the <a ui-sref="power-ups.capabilities">capabilities</a>    you wish to use in your Power-Up, with the name of the capability as the key, and the function you would like us to call
+    when a capability is executed as the value.</p>
+  <pre><code class="javascript">TrelloPowerUp.initialize({
   'board-buttons': function(t, options){
     return [{
     icon: './images/icon-white.svg',
@@ -26,21 +29,27 @@
       height: 184
     });
   }
-});</pre>
+});</code></pre>
   <p>You can find more documentation below for <a ui-sref="power-ups.client-library({'#':'capability-options'})">capability options</a>.</p>
   <h3 id="ux-methods">UX Methods</h3>
   <ul>
-    <li><strong>render(function renderer)</strong> Define a method that is called by the web client when there are updates, such as a new attachment. Attachment-Sections (and other capabilities) are not re-initialized upon changes to content such as attachments of a card to prevent flashing. render is also an important method because we may not know the current user's locale at time of initialization, but we will know it at render time.
+    <li><strong>render(function renderer)</strong> Define a method that is called by the web client when there are updates, such
+      as a new attachment. Attachment-Sections (and other capabilities) are not re-initialized upon changes to content such
+      as attachments of a card to prevent flashing. render is also an important method because we may not know the current
+      user's locale at time of initialization, but we will know it at render time.
     </li>
-    <li><strong>popup(options)</strong> Use this method to have Trello display a popup. It will be displayed adjacent to the element in the current context. Pop-ups are designed for lists of capabilities or content that a user is expected to click on. The options object can contain: 'title', 'callback', 'url', 'items', and 'search'.</li>
+    <li><strong>popup(options)</strong> Use this method to have Trello display a popup. It will be displayed adjacent to the
+      element in the current context. Pop-ups are designed for lists of capabilities or content that a user is expected to
+      click on. The options object can contain: 'title', 'callback', 'url', 'items', and 'search'.</li>
     <li><strong>closePopup()</strong> This method should be used within a popup callback to close the current popup.</li>
     <li><strong>back()</strong> This method should be used within a popup callback to return to the prior popup, if it exists.</li>
     <li><strong>overlay({url:"./url_to_file.html"})</strong> Place an iframe on top of the user's experience</li>
     <li><strong>closeOverlay()</strong> This method should be used within an overlay to close the existing overlay.</li>
     <li><strong>boardBar(options)</strong> Used to render an iframe at the bottom of the standard board view.
-      <br /> The options object can contain: url args - A list of arguments to be passed to the iframe as query parameters height Below is an example of opening a board bar from a board button. When the user clicks the board button labeled "Popup", a board bar with the contents of `board-bar.html` will be displayed.
-      <pre>
-TrelloPowerUp.initialize({
+      <br /> The options object can contain: url args - A list of arguments to be passed to the iframe as query parameters
+      height Below is an example of opening a board bar from a board button. When the user clicks the board button labeled
+      "Popup", a board bar with the contents of `board-bar.html` will be displayed.
+      <pre><code class="javascript">TrelloPowerUp.initialize({
   'board-buttons': function(t, options){
     return {
       text: 'Popup',
@@ -59,45 +68,75 @@ TrelloPowerUp.initialize({
       }
     }
   }
-});
-</pre>
+});</code></pre>
     </li>
     <li><strong>closeBoardBar()</strong> Used to close the bottom Board Bar</li>
     <li><strong>authorize(urlWithSecret, options)</strong> Pass a URL to open as a new window for OAuth authentication purposes.</li>
-    NOTE: This must be run within an onclick event from one of your iframes, otherwise the browser popup blocker will be triggered and may break your ability to communicate between your authorization window and the parent Trello window.
+    NOTE: This must be run within an onclick event from one of your iframes, otherwise the browser popup blocker will be triggered
+    and may break your ability to communicate between your authorization window and the parent Trello window.
     <li><strong>sizeTo(selector)</strong> - Sizes the current iframe based on the height of the element referenced via your selector.</li>
-    <li><strong>t.navigate({ url: 'https://trello.com/c/abc123' })</strong> Generic navigation to any url that can be handled by the Trello web client. Use very sparingly, and only as the result of a direct user interaction.</li>
-    <li><strong>t.showCard('abc123')</strong> bring up the card details (card back) for an open (non-archived) card on the current board by id (or idShort). Only use as the result of a direct user interaction.</li>
+    <li><strong>t.navigate({ url: 'https://trello.com/c/abc123' })</strong> Generic navigation to any url that can be handled
+      by the Trello web client. Use very sparingly, and only as the result of a direct user interaction.</li>
+    <li><strong>t.showCard('abc123')</strong> bring up the card details (card back) for an open (non-archived) card on the current
+      board by id (or idShort). Only use as the result of a direct user interaction.</li>
   </ul>
   <h3 id="data-methods">Data Methods</h3>
   <ul>
     <li><strong>iframe()</strong> Get access to the t object within an iframe</li>
-    <li><strong>set(scope, visibility, name, value)</strong> Used to store some persistent data in Trello's database. Multiple keys can be included in a single call - e.g. <i>t.set('board', 'shared', { key: 'value', otherKey: 55, moreKeys: false }).</i>. The Power-Up provides a scope (organization, board, or card) and the visibility of the data (i.e. whether it's ‘shared’ with everyone that can see the org/board/card or if it's ‘private’) and a string to store. Power-Ups are allowed to store 4K of data for each scope/visibility pair and the current Power-Ups store stringified JSON. Using `t.set` will re-initialize your Power-Up in it’s entirety by re-executing all capabilities. Read more about data storage in the <a ui-sref="power-ups.topics({'#':'data-storage'})">topics section</a>.
+    <li><strong>set(scope, visibility, name, value)</strong> Used to store some persistent data in Trello's database. Multiple
+      keys can be included in a single call - e.g. <i>t.set('board', 'shared', { key: 'value', otherKey: 55, moreKeys: false }).</i>.
+      The Power-Up provides a scope (organization, board, or card) and the visibility of the data (i.e. whether it's ‘shared’
+      with everyone that can see the org/board/card or if it's ‘private’) and a string to store. Power-Ups are allowed to
+      store 4K of data for each scope/visibility pair and the current Power-Ups store stringified JSON. Using `t.set` will
+      re-initialize your Power-Up in it’s entirety by re-executing all capabilities. Read more about data storage in the
+      <a ui-sref="power-ups.topics({'#':'data-storage'})">topics section</a>.
     </li>
-    <li><strong>get(scope, visibility, name, defaultValue)</strong> Used to get the stored data, at the specified scope and visibility, from the given key for the Power-Up. If defaultValue is provided and there is not a value for the given key, the defaultValue will be returned.</li>
-    <li><strong>getAll(scope, visibility, name, defaultValue)</strong> Used to return all pluginData in scope. For instance, if you have a card in context you will get back private and shared pluginData on the organization, board, and that card. If a card is not in context, you will get back private and shared pluginData on just the organization and board scopes.</li>
-    <li><strong>remove(scope, visibility, name)</strong> Used to delete the given keys and values from pluginData. <i>name</i> should be the name of the key to remove; it can be either a single string or an array of strings for which keys to remove (e.g. <i>t.remove('organization', 'shared', ['key1', 'key2', 'key3']</i></li>
+    <li><strong>get(scope, visibility, name, defaultValue)</strong> Used to get the stored data, at the specified scope and visibility,
+      from the given key for the Power-Up. If defaultValue is provided and there is not a value for the given key, the defaultValue
+      will be returned.</li>
+    <li><strong>getAll(scope, visibility, name, defaultValue)</strong> Used to return all pluginData in scope. For instance,
+      if you have a card in context you will get back private and shared pluginData on the organization, board, and that
+      card. If a card is not in context, you will get back private and shared pluginData on just the organization and board
+      scopes.
+    </li>
+    <li><strong>remove(scope, visibility, name)</strong> Used to delete the given keys and values from pluginData. <i>name</i>      should be the name of the key to remove; it can be either a single string or an array of strings for which keys to
+      remove (e.g. <i>t.remove('organization', 'shared', ['key1', 'key2', 'key3']</i></li>
     <li><strong>attach({url:URL, name:Name})</strong> Attach a new URL to the card in the current context.</li>
     <li><strong>signUrl(URL)</strong> Sign a URL for use with <strong>attachment-sections</strong> only.</li>
     <li><strong>localizeKey(key, data)</strong> Localize a string by key</li>
-    <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalizationa and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
-    <li><strong>board(field1, field2, ...)</strong> Returns a promise with information about the board for the current context. Valid fields include: 'id', 'name', 'url', 'shortLink', 'members'</li>
-    <li><strong>list(field1, field2, ...)</strong> Returns a promise with information about the list for the current context Valid fields include: 'id', 'name', 'cards'</li>
-    <li><strong>card(field1, field2, ...)</strong> Returns a promise with information about the card for the current context. The information available is only when a specific card is in context. For instance, this function will return information about a card successfully inside of the capabilities 'attachment-sections' and 'card-badges', but not 'show-settings' nor 'board-buttons'. The latter are not within the context of a single card. Valid fields include: 'id', 'name', 'desc', 'due', 'closed', 'cover', 'attachments', 'members', 'labels', 'url', 'shortLink', 'idList', 'idShort'
+    <li><strong>localizeKeys(keys)</strong> Localize a list of strings or objects. You can read more about internationalizationa
+      and localization in the <a ui-sref="power-ups.topics({'#':'internationalization'})">topics section</a>.</li>
+    <li><strong>board(field1, field2, ...)</strong> Returns a promise with information about the board for the current context.
+      Valid fields include: 'id', 'name', 'url', 'shortLink', 'members'</li>
+    <li><strong>list(field1, field2, ...)</strong> Returns a promise with information about the list for the current context
+      Valid fields include: 'id', 'name', 'cards'</li>
+    <li><strong>card(field1, field2, ...)</strong> Returns a promise with information about the card for the current context.
+      The information available is only when a specific card is in context. For instance, this function will return information
+      about a card successfully inside of the capabilities 'attachment-sections' and 'card-badges', but not 'show-settings'
+      nor 'board-buttons'. The latter are not within the context of a single card. Valid fields include: 'id', 'name', 'desc',
+      'due', 'closed', 'cover', 'attachments', 'members', 'labels', 'url', 'shortLink', 'idList', 'idShort'
       <br />
       <br /> Example usage:
-      <pre>t.card('id', 'name', 'url').then(function(promiseResult){console.log(promiseResult)});
-// <- {id:"72hejh3iuruyr87rhiu", name: "Card Name", url: "https://trello.com/c/38UCRu1a/card-name"}</pre>
+      <pre><code class="javascript">t.card('id', 'name', 'url')
+.then(function(promiseResult) {
+  console.log(promiseResult);
+});</code></pre>
+      <pre><code class="javascript">{
+  id: "72hejh3iuruyr87rhiu",
+  name: "Card Name",
+  url: "https://trello.com/c/38UCRu1a/card-name"
+}</code></pre>
     </li>
     <li><strong>t.lists</strong> Takes same args as <i>t.list</i> but gives back all open lists on the board</li>
-    <li><strong>t.member</strong> Accepted fields: 'id', 'fullName', 'username', 'avatar'. This is an easy way to get information about active members. 'avatar' returns the complete URL for the 50px png file.</li>
+    <li><strong>t.member</strong> Accepted fields: 'id', 'fullName', 'username', 'avatar'. This is an easy way to get information
+      about active members. 'avatar' returns the complete URL for the 50px png file.</li>
     <li><strong>t.cards</strong> Takes same args as <i>t.card</i> but gives back all open cards on the board.</li>
   </ul>
   <h3 id="capability-options">Capability Options</h3>
-  <p>Each capability that you include in your initialization will take a reference to the <strong>t</strong> object and a options or context object. This object will include various things depending on the capability.</p>
+  <p>Each capability that you include in your initialization will take a reference to the <strong>t</strong> object and a options
+    or context object. This object will include various things depending on the capability.</p>
   <p>Board Capability Options</p>
-  <pre>
-"{
+  <pre><code class="json">{
   "context": {
     "member": "556c8537a1928ba745504ad8",
     "permissions": {
@@ -108,11 +147,9 @@ TrelloPowerUp.initialize({
     "__insecure_signature": "69eda4985e3fa8c7286cf626-f65bc7b"
   },
   "locale": "en-US"
-}"
-</pre>
+}</code></pre>
   <p>Card Capability Options</p>
-  <pre>
-"{
+  <pre><code class="json">{
   "context": {
     "member": "556c8537a1928ba745504ad8",
     "permissions": {
@@ -126,14 +163,21 @@ TrelloPowerUp.initialize({
     "__insecure_signature": "69eda4985e3fa8c7286cf626-f65bc7b"
   },
   "locale": "en-US"
-}"
-  </pre>
+}</code></pre>
   <p>Attachment Sections Options</p>
-  <pre>{
+  <pre><code class="json">{
   "entries":[
-    {"id":"56a2467476812315cbbbcbe4","url":"https://example.org/url","name":"https://example.org/url"},
+    {
+      "id":"56a2467476812315cbbbcbe4",
+      "url":"https://example.org/url",
+      "name":"https://example.org/url"
+    },
     ...
-    {"id":"569e5ab156d89775e853ebb4","url":"https://example.org/url","name":"Attachment Name"}
+    {
+      "id":"569e5ab156d89775e853ebb4",
+      "url":"https://example.org/url",
+      "name":"Attachment Name"
+    }
   ],
   "context":{
     "board":"55db14fd3e105ac8b105bd75",
@@ -141,13 +185,21 @@ TrelloPowerUp.initialize({
     "command":"attachment-sections",
     "options":{
       "entries":[
-        {"id":"56a2467476812315cbbbcbe4","url":"https://example.org/url","name":"https://example.org/url"},
+        {
+          "id":"56a2467476812315cbbbcbe4",
+          "url":"https://example.org/url",
+          "name":"https://example.org/url"
+        },
         ...
-        {"id":"569e5ab156d89775e853ebb4","url":"https://example.org/url","name":"Attachment Name"}
+        {
+          "id":"569e5ab156d89775e853ebb4",
+          "url":"https://example.org/url",
+          "name":"Attachment Name"
+        }
       ]
     },
     "plugin":"564ddf493f183b88ea5ddc0e"
   },
   "locale":"en-US"
-}</pre>
+}</code></pre>
 </div>

--- a/app/templates/power-ups/topics.html
+++ b/app/templates/power-ups/topics.html
@@ -46,8 +46,7 @@
   <h2 id="menus">Menus</h2>
   <p>Often you will want to render Menus to the member, such as in response to clicking on a card-button. This code is invoked as the callback when a member clicks on the card-button returned as part of the plugin initialization. Initially the callback runs the t.popup method and provides two hardcoded options. If the user clicks on one of these options, we then create an overlay via t.overlay that loads the appropriate interface in a new iframe.</p>
   <p>Below is a sample callback from our Dropbox integration:</p>
-  <pre>
-var attachFile = function(t) {
+  <pre><code class="javascript">var attachFile = function(t) {
   return t.overlay({
     url: 'attach.html'
   })
@@ -79,8 +78,7 @@ module.exports = function(t) {
       }
     ]
   });
-}
-  </pre>
+}</code></pre>
   <p>Popups can be nested, which will automatically provide a back button in the corner of the popup. You can also request that search be allowed on the popup. This will provide native web client functionality for performing full text searches of your supplied items.</p>
   <p>Alternatively, popups can be created containing an iframe by supplying a title, URL, and height instead of a set of items.</p>
   <hr/>
@@ -89,7 +87,7 @@ module.exports = function(t) {
   <p>Attachments can be created with the <strong>t.attach</strong> method, but they can only be removed by the user using the standard web experience in the attachments section, or by clicking in the upper right hand corner of an attachment-section claiming an attachment. `t.attach` will fail if the member (on whose behalf the Power-Up is making the request) does not have write access to the board. Your Power-Up can check this ahead of time using the permissions object in the context. If permissions.card === 'write' you should be good to go. To access the context when using `TrelloPowerUp.iframe()`, you can do so like: <br />
   `const canEdit = t.args[0].context.permissions.board === 'write';`</p>
   <p>The context has a permissions property, with sub-properties of card, board, and organization. If you look at the context and look at permissions.card and see that it is 'write' then you can generally expect this call will succeed. Power-Ups may want to alter their behavior (for example not even showing a button at all) based on the permissions of the current user.</p>
-  <pre>t.attach({ url: url });</pre>
+  <pre><code class="javascript">t.attach({ url: url });</code></pre>
   <img src="/images/content/sample-remove-attachments.png" alt="Remove attachments via popup" />
   <p>The names of each attachment in the “Remove Attachments” popup are rendered using <strong>format-url</strong>.</p>
   <hr/>
@@ -105,8 +103,7 @@ module.exports = function(t) {
   <p>When developing a Power-Up that requires authentication, try to offer as much functionality in a non-authenticated state as possible, and add non-intrusive links to authenticate the user to provide more functionality.</p>
   <p>To achieve Authentication, you will often need to use the t.authenticate method. Here’s a code sample of how you might handle the OAuth workflow from within a Power-Up popover iframe.</p>
   <p>Client side we need to wire up what should happen when the authenticate button or link is clicked, which is handled by the following code.</p>
-  <pre>
-var Promise = TrelloPowerUp.Promise;
+  <pre><code class="javascript">var Promise = TrelloPowerUp.Promise;
 var t = TrelloPowerUp.iframe();
 
 var oauthUrl = 'https://trello.com/1/authorize?expiration=never' +
@@ -138,19 +135,16 @@ authBtn.addEventListener('click', function() {
     // you might alternatively choose to open a new popup
     return t.closePopup();
   });
-});
-  </pre>
+});</code></pre>
   <p>The authorize handler opens a new window. Once the auth flow is complete in that window, you should land on a page you control (generally your return_url). That page needs to contain a small amount of javascript to send the resulting token back to the Power-Up.</p>
   <p>Here is an example of how that would be achieved for the Trello OAuth flow from above:</p>
-  <pre>
-var token = window.location.hash.substring(7);
+  <pre><code class="javascript">var token = window.location.hash.substring(7);
 if (window.opener && typeof window.opener.authorize === 'function') {
   window.opener.authorize(token);
 } else {
   localStorage.setItem('token', token);
 }
-setTimeout(function(){ window.close(); }, 1000);
-  </pre>
+setTimeout(function(){ window.close(); }, 1000);</code></pre>
   <hr/>
 
   <h2 id="data-storage">Data Storage</h2>
@@ -180,15 +174,15 @@ setTimeout(function(){ window.close(); }, 1000);
     </tbody>
   </table>
   <p>You can store data two ways:</p>
-  <pre>t.set('board', 'private', 'key', value)</pre>
+  <pre><code class="javascript">t.set('board', 'private', 'key', value)</code></pre>
   <p>or</p>
-  <pre>t.set('board', 'private', { key1: value1, key2: value2 })</pre>
+  <pre><code class="javascript">t.set('board', 'private', { key1: value1, key2: value2 })</code></pre>
   <p>Storing at the 'organization' scope will only work if the both the board is in a team and the active user is a member of the team to which the board belongs. Because the 'organization' scope is not always available, you should add a catch whenever trying to set data at the 'organization' level and fallback to the 'board' level, if necessary. For example:</p>
-<pre>t.set('organization', 'private', 'key', 'value')
+<pre><code class="javascript">t.set('organization', 'private', 'key', 'value')
   .catch(t.NotHandled, function() {
     // fall back to storing at board level
     return t.set('board', 'private', 'key', 'value');
-});</pre>
+});</code></pre>
   <p>Members can reset their private data at any time via the Power-Ups menu.</p>
   <p>Shared Power-Up data is available via the API at the <a href="./advanced-reference/organization#get-1-organizations-idorg-or-name-pluginData">organization</a>, <a href="./advanced-reference/board#get-1-boards-board-id-pluginData">board</a>, and <a href="./advanced-reference/card#get-1-cards-card-id-or-shortlink-pluginData">card</a> level. Each resource returns the data (named pluginData) that was set at that scope. For instance, `1/card/IdCard/pluginData` will return data set with `t.set('card', 'shared', 'key', 'value')`. Currently, pluginData is read-only and can not be set via the API. Data set within the private scope is not available via the API.</p>
   </hr>
@@ -201,21 +195,21 @@ setTimeout(function(){ window.close(); }, 1000);
   <h2 id="internationalization">Internationalization</h2>
   <p>Trello Power-Ups were designed with Internationalization in mind. When creating a plugin or iframe, you can optionally pass in the options argument one of the following:</p>
   <p>localization object</p>
-  <pre>localization: {
+  <pre><code class="javascript">localization: {
   defaultLocale: 'en',
   supportedLocales: ['en', 'fr'],
   resourceUrl: './strings/{locale}.json'
-}</pre>
+}</code></pre>
   <p>localizer object</p>
-  <pre>localizer: {
+  <pre><code class="javascript">localizer: {
   localize: function(key, data){
     ... synchronously returns a localized string for the given key and data ...
   }
-}</pre>
+}</code></pre>
   <p>loadLocalizer function</p>
-  <pre>loadLocalizer: function(locale){
+  <pre><code class="javascript">loadLocalizer: function(locale){
     ... returns a Promise that resolves to a localizer object ...
-  }</pre>
+  }</code></pre>
   <p>Additionally, you can set window.localizer to your own custom localizer and the HostHandlers will use it.</p>
   <p>Once a localizer has been initialized, you can call the following new handlers (which behind the scenes make use of the localizer). We make the current user locale available to you via window.locale. Additionally, you can grab it off the options object from any of the interfaces or callbacks as well.</p>
   <p><strong>localizeKey(key, data)</strong> synchronously returns the output of window.localizer.localize(key, data)</p>
@@ -224,16 +218,16 @@ setTimeout(function(){ window.close(); }, 1000);
   <p><strong>localizeNode(node)</strong> synchronously inserts localized texts into DOM nodes starting at the provided node and all of it's children. Tag a node in your HTML with data-i18n-id="key" for its text content to be replaced based on that key. You can pass args with data-i18n-args='{ "arg1": "data" }'. You can also have placeholder text replaced with data-i18n-attrs='{ "placeholder": "key" }'. This will also use the args defined in data-i18n-args.</p>
   <p>Currently there is no support for dot notation when replacing args.</p>
   <p>Argument replacement assumes that your resource file follows this format:</p>
-  <pre>{
+  <pre><code class="json">{
   "key": "value with replaceable {arguments}"
-}</pre>
+}</code></pre>
   <p>Again, dot notation is not supported for arguments. This also limits how you can use braces {} in that there is no escaping currently supported.</p>
   <hr/>
 
   <h2 id="callbacks">Callbacks</h2>
   <h3>What are callbacks?</h3>
   <p>Callbacks are functions that get called in response to a user taking an action within a capability. Trello provides a number of capabilities with default UI. For instance, the <a href="/power-ups/capabilities#card-detail-badges">'card-detail-badges' capability</a> allows you to create a badge on a card with a given set of parameters. Trello takes care of rendering the badge appropriately. If you want something to happen when the user clicks the badge, you can provide a callback to be called.</p>
-  
+
   <h3>How are callbacks used?</h3>
   <p>For example, a Power-Up might request that a popover list be displayed with 20 items in it. Each of the items has a callback associated with it, but only the one corresponding to the thing that gets clicked on would be called.</p>
   <p>Callbacks can also be used to supply the most recent state of the badge on a card (in that case, the same callback might be called many times). Or a callback could be associated with the button in the board header and the same callback would be triggered every time the button was clicked.</p>


### PR DESCRIPTION
## Description

Adds syntax highlighting to all code blocks displayed in the Power-Up docs.

## Screenshots

![screen shot 2017-04-07 at 4 13 56 pm](https://cloud.githubusercontent.com/assets/1246035/24819056/04b3b3a2-1bb1-11e7-846c-4f17f9016e80.png)
![screen shot 2017-04-07 at 4 14 34 pm](https://cloud.githubusercontent.com/assets/1246035/24819057/04b5c2d2-1bb1-11e7-871d-fbdb756d0831.png)
