### PR TITLE
Update boards routes with syntax highlighting and fix example hiding

### DIFF
--- a/app/templates/docs/board.html
+++ b/app/templates/docs/board.html
@@ -2,17 +2,22 @@
 <h1>board
   <a class="headerlink" href="#board" title="Permalink to this headline"></a>
 </h1>
+
+<!-- /1/boards/id -->
+
 <div class="section" id="get-1-boards-board-id">
   <h2>GET <span class="target" id="boards-board-id">/1/boards/[board_id]</span>
     <a class="headerlink" href="#get-1-boards-board-id" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">actions</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">addAttachmentToCard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">addChecklistToCard</span></code></li>
@@ -103,19 +108,21 @@
         </li>
         <li><code class="docutils literal"><span class="pre">actions_since</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> A date, <code class="docutils literal"><span class="pre">null</span></code> or <code class="docutils literal"><span class="pre">lastView</span></code></li>
+            <li><strong>Valid Values:</strong> A date, <code class="docutils literal"><span class="pre">null</span></code> or
+              <code class="docutils literal"><span class="pre">lastView</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">actions_limit</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">50</span></code></li>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">action_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">data</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -139,7 +146,8 @@
         <li><code class="docutils literal"><span class="pre">action_member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -171,7 +179,8 @@
         <li><code class="docutils literal"><span class="pre">action_memberCreator_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -206,7 +215,8 @@
         <li><code class="docutils literal"><span class="pre">card_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -245,7 +255,8 @@
         <li><code class="docutils literal"><span class="pre">card_attachment_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">bytes</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -318,7 +329,8 @@
         <li><code class="docutils literal"><span class="pre">label_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">color</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -331,7 +343,7 @@
         <li><code class="docutils literal"><span class="pre">labels_limit</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">50</span></code></li>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">lists</span></code> (optional)
@@ -350,7 +362,8 @@
         <li><code class="docutils literal"><span class="pre">list_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -364,7 +377,8 @@
         <li><code class="docutils literal"><span class="pre">memberships</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">none</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">active</span></code></li>
                 <li><code class="docutils literal"><span class="pre">admin</span></code></li>
@@ -389,7 +403,8 @@
         <li><code class="docutils literal"><span class="pre">memberships_member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -424,7 +439,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,initials,fullName,username,confirmed</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -459,7 +475,8 @@
         <li><code class="docutils literal"><span class="pre">membersInvited_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,initials,fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -502,7 +519,8 @@
         <li><code class="docutils literal"><span class="pre">checklist_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idCard</span></code></li>
@@ -526,7 +544,8 @@
         <li><code class="docutils literal"><span class="pre">organization_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">name,displayName</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">billableMemberCount</span></code></li>
                 <li><code class="docutils literal"><span class="pre">desc</span></code></li>
@@ -551,7 +570,8 @@
         <li><code class="docutils literal"><span class="pre">organization_memberships</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">none</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">active</span></code></li>
                 <li><code class="docutils literal"><span class="pre">admin</span></code></li>
@@ -599,7 +619,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">name,desc,descData,closed,idOrganization,pinned,url,shortUrl,prefs,labelNames</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
                 <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code></li>
@@ -626,37 +647,138 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe?key=[key]&amp;token=[token]</pre>
+          </div>
+          <pre><code class="json">{
+  "id": "560bf4298b3dda300c18d09c",
+  "name": "US National Parks",
+  "desc": "",
+  "descData": null,
+  "closed": false,
+  "idOrganization": "577eb8850b41e08c3034aae2",
+  "pinned": false,
+  "url": "https://trello.com/b/tBmYPSYe/us-national-parks",
+  "shortUrl": "https://trello.com/b/tBmYPSYe",
+  "prefs": {
+    "permissionLevel": "public",
+    "voting": "disabled",
+    "comments": "members",
+    "invitations": "members",
+    "selfJoin": true,
+    "cardCovers": true,
+    "cardAging": "regular",
+    "calendarFeedEnabled": false,
+    "background": "560bfbb5176d070c67adc2b9",
+    "backgroundImage": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1920x1080/b5ab43954a54880e455d3b4e5109644c/Bryce_Canyon.jpg",
+    "backgroundImageScaled": [
+      {
+        "width": 140,
+        "height": 100,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/140x100/cf6ffdfac5ecf934ec324bf028b82686/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 256,
+        "height": 192,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/256x192/2189d1f2d6c159c7de210412cc0e971f/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 480,
+        "height": 480,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/480x480/62bde347e629774a83378caf61f0fdb7/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 960,
+        "height": 960,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/960x960/3102fa79837dfd37834cfaee02d1921c/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 1024,
+        "height": 1024,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1024x1024/53a50ede7425af0b02a7b9bde783fe94/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 1280,
+        "height": 1280,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1280x1280/491f54004976a4a81706caae613acf7f/Bryce_Canyon.jpg"
+      },
+      {
+        "width": 1920,
+        "height": 1080,
+        "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1920x1080/b5ab43954a54880e455d3b4e5109644c/Bryce_Canyon.jpg"
+      }
+    ],
+    "backgroundTile": false,
+    "backgroundBrightness": "light",
+    "canBePublic": false,
+    "canBeOrg": false,
+    "canBePrivate": false,
+    "canInvite": true
+  },
+  "labelNames": {
+    "green": "Visited",
+    "yellow": "",
+    "orange": "",
+    "red": "",
+    "purple": "",
+    "blue": "",
+    "sky": "",
+    "lime": "",
+    "pink": "",
+    "black": ""
+  }
+}</code></pre>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe?fields=id,name,idOrganization,dateLastActivity&amp;lists=open&amp;list_fields=id,name&amp;key=[key]&amp;token=[token]</pre>
+          </div>
+          <pre><code class="json">{
+  "id": "560bf4298b3dda300c18d09c",
+  "name": "US National Parks",
+  "idOrganization": "577eb8850b41e08c3034aae2",
+  "dateLastActivity": "2016-08-07T00:49:38.995Z",
+  "lists": [
+    {
+      "id": "560bf446f17023a3710658fb",
+      "name": "Alaska"
+    },
+    {
+      "id": "560bf44ea68b16bd0fc2a9a9",
+      "name": "Arizona"
+    },
+    {
+      "id": "560bf4505d1d723b142c2c0a",
+      "name": "Arkansas"
+    },
+    {
+      "id": "560bf45374e3026dca43aedb",
+      "name": "California"
+    },
+    {
+      "id": "560bf45b7e62e2cb4852388b",
+      "name": "Colorado"
+    }
+    ...
+  ]
+}</code></pre>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046?lists=open&amp;list_fields=name&amp;fields=name,desc&amp;key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;desc&quot;</span><span class="o">:</span> <span class="s2">&quot;This board is used in the API examples&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;lists&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004a&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;To Do Soon&quot;</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004b&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Doing&quot;</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004c&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Done&quot;</span>
-  <span class="p">}]</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/field -->
+
 <div class="section" id="get-1-boards-board-id-field">
   <h2>GET <span class="target" id="boards-board-id-field">/1/boards/[board_id]/[field]</span>
     <a class="headerlink" href="#get-1-boards-board-id-field" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">field</span></code> (required)
           <ul>
@@ -687,240 +809,176 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/closed?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": false }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/dateLastActivity?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "2016-08-07T00:49:38.995Z" }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/dateLastView?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "2017-04-10T15:41:44.098Z" }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/idOrganization?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "577eb8850b41e08c3034aae2" }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/labelNames?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{
+  "green": "Visited",
+  "yellow": "",
+  "orange": "",
+  "red": "",
+  "purple": "",
+  "blue": "",
+  "sky": "",
+  "lime": "",
+  "pink": "",
+  "black": ""
+}</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/memberships?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[
+  {
+    "id": "560bf4298b3dda300c18d09d",
+    "idMember": "556c8537a1928ba745504dd8",
+    "memberType": "admin",
+    "unconfirmed": false,
+    "deactivated": false
+  },
+  {
+    "id": "58ebc5d5abcedaf34a60800e",
+    "idMember": "56fd3de8ba3cbeb22737fd55",
+    "memberType": "normal",
+    "unconfirmed": false,
+    "deactivated": false
+  }
+]</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/name?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "US National Parks" }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/prefs?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{
+  "permissionLevel": "public",
+  "voting": "disabled",
+  "comments": "members",
+  "invitations": "members",
+  "selfJoin": true,
+  "cardCovers": true,
+  "cardAging": "regular",
+  "calendarFeedEnabled": false,
+  "background": "560bfbb5176d070c67adc2b9",
+  "backgroundImage": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1920x1080/b5ab43954a54880e455d3b4e5109644c/Bryce_Canyon.jpg",
+  "backgroundImageScaled": [
+    {
+      "width": 140,
+      "height": 100,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/140x100/cf6ffdfac5ecf934ec324bf028b82686/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 256,
+      "height": 192,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/256x192/2189d1f2d6c159c7de210412cc0e971f/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 480,
+      "height": 480,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/480x480/62bde347e629774a83378caf61f0fdb7/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 960,
+      "height": 960,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/960x960/3102fa79837dfd37834cfaee02d1921c/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 1024,
+      "height": 1024,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1024x1024/53a50ede7425af0b02a7b9bde783fe94/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 1280,
+      "height": 1280,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1280x1280/491f54004976a4a81706caae613acf7f/Bryce_Canyon.jpg"
+    },
+    {
+      "width": 1920,
+      "height": 1080,
+      "url": "https://trello-backgrounds.s3.amazonaws.com/556c8537a1928ba745504dd8/1920x1080/b5ab43954a54880e455d3b4e5109644c/Bryce_Canyon.jpg"
+    }
+  ],
+  "backgroundTile": false,
+  "backgroundBrightness": "light",
+  "canBePublic": false,
+  "canBeOrg": false,
+  "canBePrivate": false,
+  "canInvite": true
+}</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/shortLink?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "tBmYPSYe" }</code></pre>
+          </div>
+
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/shortUrl?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">{ "_value": "https://trello.com/b/tBmYPSYe" }</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/closed?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/dateLastActivity?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">null</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/dateLastView?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">null</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/desc?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;This board is used in the API examples&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/descData?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">null</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/idOrganization?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;4efe2c2f2e1efe7a4c0002c9&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/invitations?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[]</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/invited?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/labelNames?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;green&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;yellow&quot;</span><span class="o">:</span> <span class="s2">&quot;Low Priority&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;orange&quot;</span><span class="o">:</span> <span class="s2">&quot;Medium Priority&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;red&quot;</span><span class="o">:</span> <span class="s2">&quot;High Priority&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;purple&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;blue&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;sky&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;lime&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pink&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;black&quot;</span><span class="o">:</span> <span class="s2">&quot;&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/memberships?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004d&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;memberType&quot;</span><span class="o">:</span> <span class="s2">&quot;admin&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;unconfirmed&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea507991e31d17460000fc&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df1be582acdec80000ae&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;memberType&quot;</span><span class="o">:</span> <span class="s2">&quot;normal&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;unconfirmed&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea50bc91e31d174600016d&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;memberType&quot;</span><span class="o">:</span> <span class="s2">&quot;normal&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;unconfirmed&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/name?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/pinned?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">false</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/powerUps?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[]</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/prefs?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;permissionLevel&quot;</span><span class="o">:</span> <span class="s2">&quot;public&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;voting&quot;</span><span class="o">:</span> <span class="s2">&quot;members&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;comments&quot;</span><span class="o">:</span> <span class="s2">&quot;members&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;invitations&quot;</span><span class="o">:</span> <span class="s2">&quot;members&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;selfJoin&quot;</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
-  <span class="s2">&quot;cardCovers&quot;</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
-  <span class="s2">&quot;calendarFeedEnabled&quot;</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
-  <span class="s2">&quot;background&quot;</span><span class="o">:</span> <span class="s2">&quot;blue&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;backgroundColor&quot;</span><span class="o">:</span> <span class="s2">&quot;#0079BF&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;backgroundImage&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;backgroundImageScaled&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;backgroundTile&quot;</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
-  <span class="s2">&quot;backgroundBrightness&quot;</span><span class="o">:</span> <span class="s2">&quot;unknown&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;canBePublic&quot;</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
-  <span class="s2">&quot;canBeOrg&quot;</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
-  <span class="s2">&quot;canBePrivate&quot;</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
-  <span class="s2">&quot;canInvite&quot;</span><span class="o">:</span> <span class="kc">true</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/shortLink?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;OXiBYZoj&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/shortUrl?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/b/OXiBYZoj&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/starred?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">null</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/subscribed?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="kc">null</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/url?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">{</span>
-  <span class="s2">&quot;_value&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/b/OXiBYZoj/example-board&quot;</span>
-<span class="p">}</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/actions -->
+
 <div class="section" id="get-1-boards-board-id-actions">
   <h2>GET <span class="target" id="boards-board-id-actions">/1/boards/[board_id]/actions</span>
     <a class="headerlink" href="#get-1-boards-board-id-actions" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">entities</span></code> (optional)
           <ul>
@@ -947,7 +1005,8 @@
         <li><code class="docutils literal"><span class="pre">filter</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">addAttachmentToCard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">addChecklistToCard</span></code></li>
@@ -1005,7 +1064,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">data</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -1018,7 +1078,7 @@
         <li><code class="docutils literal"><span class="pre">limit</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">50</span></code></li>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">format</span></code> (optional)
@@ -1035,7 +1095,8 @@
         </li>
         <li><code class="docutils literal"><span class="pre">since</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> A date, <code class="docutils literal"><span class="pre">null</span></code> or <code class="docutils literal"><span class="pre">lastView</span></code></li>
+            <li><strong>Valid Values:</strong> A date, <code class="docutils literal"><span class="pre">null</span></code> or
+              <code class="docutils literal"><span class="pre">lastView</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">before</span></code> (optional)
@@ -1068,7 +1129,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -1100,7 +1162,8 @@
         <li><code class="docutils literal"><span class="pre">memberCreator_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -1120,137 +1183,144 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/actions?filter=addMemberToCard,removeMemberFromCard&amp;key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[{
+  "id": "4eea523791e31d17460002a0",
+  "data": {
+    "card": {
+      "id": "4eea522c91e31d174600027e",
+      "name": "Figure out how to read a user&#39;s board list"
+    },
+    "board": {
+      "id": "4eea4ffc91e31d1746000046",
+      "name": "Example Board"
+    },
+    "idMember": "4ee7df74e582acdec80000b6"
+  },
+  "date": "2011-12-15T20:01:59.688Z",
+  "idMemberCreator": "4ee7deffe582acdec80000ac",
+  "type": "addMemberToCard",
+  "member": {
+    "id": "4ee7df74e582acdec80000b6",
+    "avatarHash": "c9903e2464563d83e38df3afd685dc6c",
+    "fullName": "David Tester",
+    "initials": "DT",
+    "username": "davidtester"
+  },
+  "memberCreator": {
+    "id": "4ee7deffe582acdec80000ac",
+    "avatarHash": null,
+    "fullName": "Joe Tester",
+    "initials": "JT",
+    "username": "joetester"
+  }
+}, {
+  "id": "4eea515291e31d17460001f9",
+  "data": {
+    "card": {
+      "id": "4eea502b91e31d1746000071",
+      "name": "Find out where the Trello API documentation is"
+    },
+    "board": {
+      "id": "4eea4ffc91e31d1746000046",
+      "name": "Example Board"
+    },
+    "idMember": "4ee7df1be582acdec80000ae"
+  },
+  "date": "2011-12-15T19:58:10.748Z",
+  "idMemberCreator": "4ee7deffe582acdec80000ac",
+  "type": "addMemberToCard",
+  "member": {
+    "id": "4ee7df1be582acdec80000ae",
+    "avatarHash": null,
+    "fullName": "Bob Tester",
+    "initials": "BT",
+    "username": "bobtester"
+  },
+  "memberCreator": {
+    "id": "4ee7deffe582acdec80000ac",
+    "avatarHash": null,
+    "fullName": "Joe Tester",
+    "initials": "JT",
+    "username": "joetester"
+  }
+}, {
+  "id": "4eea515091e31d17460001e7",
+  "data": {
+    "card": {
+      "id": "4eea501f91e31d1746000062",
+      "name": "Get a key to use in my API requests"
+    },
+    "board": {
+      "id": "4eea4ffc91e31d1746000046",
+      "name": "Example Board"
+    },
+    "idMember": "4ee7df74e582acdec80000b6"
+  },
+  "date": "2011-12-15T19:58:08.053Z",
+  "idMemberCreator": "4ee7deffe582acdec80000ac",
+  "type": "addMemberToCard",
+  "member": {
+    "id": "4ee7df74e582acdec80000b6",
+    "avatarHash": "c9903e2464563d83e38df3afd685dc6c",
+    "fullName": "David Tester",
+    "initials": "DT",
+    "username": "davidtester"
+  },
+  "memberCreator": {
+    "id": "4ee7deffe582acdec80000ac",
+    "avatarHash": null,
+    "fullName": "Joe Tester",
+    "initials": "JT",
+    "username": "joetester"
+  }
+}, {
+  "id": "4eea504191e31d174600009f",
+  "data": {
+    "card": {
+      "id": "4eea503d91e31d174600008f",
+      "name": "Learn about the Trello API"
+    },
+    "board": {
+      "id": "4eea4ffc91e31d1746000046",
+      "name": "Example Board"
+    },
+    "idMember": "4ee7deffe582acdec80000ac"
+  },
+  "date": "2011-12-15T19:53:37.323Z",
+  "idMemberCreator": "4ee7deffe582acdec80000ac",
+  "type": "addMemberToCard",
+  "member": {
+    "id": "4ee7deffe582acdec80000ac",
+    "avatarHash": null,
+    "fullName": "Joe Tester",
+    "initials": "JT",
+    "username": "joetester"
+  },
+  "memberCreator": {
+    "id": "4ee7deffe582acdec80000ac",
+    "avatarHash": null,
+    "fullName": "Joe Tester",
+    "initials": "JT",
+    "username": "joetester"
+  }
+}]</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/actions?filter=addMemberToCard,removeMemberFromCard&amp;key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea523791e31d17460002a0&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;data&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;card&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea522c91e31d174600027e&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Figure out how to read a user&#39;s board list&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;board&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;date&quot;</span><span class="o">:</span> <span class="s2">&quot;2011-12-15T20:01:59.688Z&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMemberCreator&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;type&quot;</span><span class="o">:</span> <span class="s2">&quot;addMemberToCard&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;member&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="s2">&quot;c9903e2464563d83e38df3afd685dc6c&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;David Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;DT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;davidtester&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;memberCreator&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;JT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-  <span class="p">}</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea515291e31d17460001f9&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;data&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;card&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea502b91e31d1746000071&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Find out where the Trello API documentation is&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;board&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df1be582acdec80000ae&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;date&quot;</span><span class="o">:</span> <span class="s2">&quot;2011-12-15T19:58:10.748Z&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMemberCreator&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;type&quot;</span><span class="o">:</span> <span class="s2">&quot;addMemberToCard&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;member&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df1be582acdec80000ae&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Bob Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;BT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;bobtester&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;memberCreator&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;JT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-  <span class="p">}</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea515091e31d17460001e7&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;data&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;card&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea501f91e31d1746000062&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Get a key to use in my API requests&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;board&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;date&quot;</span><span class="o">:</span> <span class="s2">&quot;2011-12-15T19:58:08.053Z&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMemberCreator&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;type&quot;</span><span class="o">:</span> <span class="s2">&quot;addMemberToCard&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;member&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="s2">&quot;c9903e2464563d83e38df3afd685dc6c&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;David Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;DT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;davidtester&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;memberCreator&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;JT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-  <span class="p">}</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea504191e31d174600009f&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;data&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;card&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea503d91e31d174600008f&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Learn about the Trello API&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;board&quot;</span><span class="o">:</span> <span class="p">{</span>
-      <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-      <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Example Board&quot;</span>
-    <span class="p">},</span>
-    <span class="s2">&quot;idMember&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;date&quot;</span><span class="o">:</span> <span class="s2">&quot;2011-12-15T19:53:37.323Z&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idMemberCreator&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;type&quot;</span><span class="o">:</span> <span class="s2">&quot;addMemberToCard&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;member&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;JT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-  <span class="p">},</span>
-  <span class="s2">&quot;memberCreator&quot;</span><span class="o">:</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;avatarHash&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;initials&quot;</span><span class="o">:</span> <span class="s2">&quot;JT&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-  <span class="p">}</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/boardStars -->
+
 <div class="section" id="get-1-boards-board-id-boardstars">
   <h2>GET <span class="target" id="boards-board-id-boardstars">/1/boards/[board_id]/boardStars</span>
     <a class="headerlink" href="#get-1-boards-board-id-boardstars" title="Permalink to this headline"></a>
@@ -1274,17 +1344,22 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/cards -->
+
 <div class="section" id="get-1-boards-board-id-cards">
   <h2>GET <span class="target" id="boards-board-id-cards">/1/boards/[board_id]/cards</span>
     <a class="headerlink" href="#get-1-boards-board-id-cards" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">actions</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">addAttachmentToCard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">addChecklistToCard</span></code></li>
@@ -1348,7 +1423,8 @@
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">bytes</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -1388,7 +1464,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -1430,7 +1507,7 @@
         </li>
         <li><code class="docutils literal"><span class="pre">limit</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">since</span></code> (optional)
@@ -1460,7 +1537,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -1492,42 +1570,50 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/cards?fields=id,name,idList,url&amp;key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[
+  {
+    "id": "560bf4c750fa2c5762d68a41",
+    "name": "Denali National Park & Preserve",
+    "idList": "560bf446f17023a3710658fb",
+    "url": "https://trello.com/c/RTk2lGjW/2-denali-national-park-preserve"
+  },
+  {
+    "id": "560bf4cb1c683fb60f88c3d1",
+    "name": "Gates of the Arctic National Park",
+    "idList": "560bf446f17023a3710658fb",
+    "url": "https://trello.com/c/bxkVBX8j/3-gates-of-the-arctic-national-park"
+  },
+  {
+    "id": "560bf4ce1171d2463bf2d395",
+    "name": "Glacier Bay National Park",
+    "idList": "560bf446f17023a3710658fb",
+    "url": "https://trello.com/c/Y3oEagK6/4-glacier-bay-national-park"
+  },
+  {
+    "id": "560bf4d1ff62683214f544e9",
+    "name": "Katmai National Park and Preserve",
+    "idList": "560bf446f17023a3710658fb",
+    "url": "https://trello.com/c/6EhyQKQe/5-katmai-national-park-and-preserve"
+  },
+  ...
+]</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/cards?fields=name,idList,url&amp;key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea503791e31d1746000080&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Finish my awesome application&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idList&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004a&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;url&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/c/XlG8S7ll/3-finish-my-awesome-application&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea503d91e31d174600008f&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Learn about the Trello API&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idList&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004b&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;url&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/c/Y9eWwKiQ/4-learn-about-the-trello-api&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea522c91e31d174600027e&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Figure out how to read a user&#39;s board list&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idList&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004b&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;url&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/c/RUbgIc74/6-figure-out-how-to-read-a-user-s-board-list&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea501f91e31d1746000062&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Get a key to use in my API requests&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idList&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004c&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;url&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/c/RruF3Yv1/1-get-a-key-to-use-in-my-api-requests&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea502b91e31d1746000071&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Find out where the Trello API documentation is&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idList&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004c&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;url&quot;</span><span class="o">:</span> <span class="s2">&quot;https://trello.com/c/WOpDiqbn/2-find-out-where-the-trello-api-documentation-is&quot;</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/cards/filter -->
+
 <div class="section" id="get-1-boards-board-id-cards-filter">
   <h2>GET <span class="target" id="boards-board-id-cards-filter">/1/boards/[board_id]/cards/[filter]</span>
     <a class="headerlink" href="#get-1-boards-board-id-cards-filter" title="Permalink to this headline"></a>
@@ -1552,6 +1638,9 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/cards/id -->
+
 <div class="section" id="get-1-boards-board-id-cards-idcard">
   <h2>GET <span class="target" id="boards-board-id-cards-idcard">/1/boards/[board_id]/cards/[idCard]</span>
     <a class="headerlink" href="#get-1-boards-board-id-cards-idcard" title="Permalink to this headline"></a>
@@ -1574,7 +1663,8 @@
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">bytes</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -1591,7 +1681,8 @@
         </li>
         <li><code class="docutils literal"><span class="pre">actions</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">addAttachmentToCard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">addChecklistToCard</span></code></li>
@@ -1671,13 +1762,14 @@
         <li><code class="docutils literal"><span class="pre">actions_limit</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">50</span></code></li>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">action_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">data</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -1690,7 +1782,8 @@
         <li><code class="docutils literal"><span class="pre">action_memberCreator_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -1722,7 +1815,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,initials,fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -1754,7 +1848,8 @@
         <li><code class="docutils literal"><span class="pre">checkItemState_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">idCheckItem</span></code></li>
                 <li><code class="docutils literal"><span class="pre">state</span></code></li>
@@ -1787,7 +1882,8 @@
         <li><code class="docutils literal"><span class="pre">checklist_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idCard</span></code></li>
@@ -1800,7 +1896,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -1834,13 +1931,17 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/checklists -->
+
 <div class="section" id="get-1-boards-board-id-checklists">
   <h2>GET <span class="target" id="boards-board-id-checklists">/1/boards/[board_id]/checklists</span>
     <a class="headerlink" href="#get-1-boards-board-id-checklists" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">cards</span></code> (optional)
           <ul>
@@ -1858,7 +1959,8 @@
         <li><code class="docutils literal"><span class="pre">card_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -1902,7 +2004,8 @@
         <li><code class="docutils literal"><span class="pre">checkItem_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">name,nameData,pos,state</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">name</span></code></li>
                 <li><code class="docutils literal"><span class="pre">nameData</span></code></li>
@@ -1927,7 +2030,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idCard</span></code></li>
@@ -1939,167 +2043,174 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/checklists?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[{
+  "id": "4eea6ae1a5da7f5a49000092",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "4eea522c91e31d174600027e",
+  "name": "API Checklist",
+  "pos": 16384,
+  "checkItems": [{
+    "state": "complete",
+    "id": "4eea6aeda5da7f5a490000b9",
+    "name": "See if there is a call",
+    "nameData": null,
+    "pos": 16751
+  }, {
+    "state": "incomplete",
+    "id": "4eea6af1a5da7f5a490000cc",
+    "name": "Figure out how to use the call",
+    "nameData": null,
+    "pos": 33544
+  }, {
+    "state": "incomplete",
+    "id": "4eea6af4a5da7f5a490000e1",
+    "name": "Add it to the code",
+    "nameData": null,
+    "pos": 50647
+  }]
+}, {
+  "id": "51114ce37f727e1c0f0000c6",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "51114ce37f727e1c0f0000b7",
+  "name": "List of Checks",
+  "pos": null,
+  "checkItems": [{
+    "state": "incomplete",
+    "id": "51114ce47f727e1c0f0000d7",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 16384
+  }, {
+    "state": "incomplete",
+    "id": "51114ce47f727e1c0f0000e0",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 32768
+  }, {
+    "state": "incomplete",
+    "id": "51114ce47f727e1c0f0000e8",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 49152
+  }]
+}, {
+  "id": "511171af63d9b4401c0000c6",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "511171af63d9b4401c0000b8",
+  "name": "List of Checks",
+  "pos": null,
+  "checkItems": [{
+    "state": "incomplete",
+    "id": "511171b063d9b4401c0000d8",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 16384
+  }, {
+    "state": "incomplete",
+    "id": "511171b063d9b4401c0000e2",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 32768
+  }, {
+    "state": "incomplete",
+    "id": "511171b063d9b4401c0000e9",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 49152
+  }]
+}, {
+  "id": "511554378fca26b25a0000c6",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "511554378fca26b25a0000b9",
+  "name": "List of Checks",
+  "pos": null,
+  "checkItems": [{
+    "state": "incomplete",
+    "id": "511554378fca26b25a0000d7",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 16384
+  }, {
+    "state": "incomplete",
+    "id": "511554388fca26b25a0000de",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 32768
+  }, {
+    "state": "incomplete",
+    "id": "511554388fca26b25a0000e9",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 49152
+  }]
+}, {
+  "id": "511a5be1db9f14a2090000c8",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "511a5be0db9f14a2090000b7",
+  "name": "List of Checks",
+  "pos": null,
+  "checkItems": [{
+    "state": "incomplete",
+    "id": "511a5be1db9f14a2090000dd",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 16384
+  }, {
+    "state": "incomplete",
+    "id": "511a5be1db9f14a2090000e3",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 32768
+  }, {
+    "state": "incomplete",
+    "id": "511a5be2db9f14a2090000ea",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 49152
+  }]
+}, {
+  "id": "511e770d01f822ae4a0000c7",
+  "idBoard": "4eea4ffc91e31d1746000046",
+  "idCard": "511e770d01f822ae4a0000b7",
+  "name": "List of Checks",
+  "pos": 16384,
+  "checkItems": [{
+    "state": "incomplete",
+    "id": "511e770e01f822ae4a0000dd",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 16384
+  }, {
+    "state": "incomplete",
+    "id": "511e770e01f822ae4a0000e3",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 32768
+  }, {
+    "state": "incomplete",
+    "id": "511e770e01f822ae4a0000ea",
+    "name": "Check Item",
+    "nameData": null,
+    "pos": 49152
+  }]
+}]</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/checklists?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea6ae1a5da7f5a49000092&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea522c91e31d174600027e&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;API Checklist&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;complete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea6aeda5da7f5a490000b9&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;See if there is a call&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16751</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea6af1a5da7f5a490000cc&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Figure out how to use the call&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">33544</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea6af4a5da7f5a490000e1&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Add it to the code&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">50647</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;51114ce37f727e1c0f0000c6&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;51114ce37f727e1c0f0000b7&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;List of Checks&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;51114ce47f727e1c0f0000d7&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;51114ce47f727e1c0f0000e0&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">32768</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;51114ce47f727e1c0f0000e8&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">49152</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511171af63d9b4401c0000c6&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;511171af63d9b4401c0000b8&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;List of Checks&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511171b063d9b4401c0000d8&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511171b063d9b4401c0000e2&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">32768</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511171b063d9b4401c0000e9&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">49152</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511554378fca26b25a0000c6&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;511554378fca26b25a0000b9&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;List of Checks&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511554378fca26b25a0000d7&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511554388fca26b25a0000de&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">32768</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511554388fca26b25a0000e9&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">49152</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511a5be1db9f14a2090000c8&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;511a5be0db9f14a2090000b7&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;List of Checks&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511a5be1db9f14a2090000dd&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511a5be1db9f14a2090000e3&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">32768</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511a5be2db9f14a2090000ea&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">49152</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511e770d01f822ae4a0000c7&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idBoard&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d1746000046&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;idCard&quot;</span><span class="o">:</span> <span class="s2">&quot;511e770d01f822ae4a0000b7&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;List of Checks&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span><span class="p">,</span>
-  <span class="s2">&quot;checkItems&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511e770e01f822ae4a0000dd&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">16384</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511e770e01f822ae4a0000e3&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">32768</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;state&quot;</span><span class="o">:</span> <span class="s2">&quot;incomplete&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;511e770e01f822ae4a0000ea&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Check Item&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;nameData&quot;</span><span class="o">:</span> <span class="kc">null</span><span class="p">,</span>
-    <span class="s2">&quot;pos&quot;</span><span class="o">:</span> <span class="mi">49152</span>
-  <span class="p">}]</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/deltas -->
+
 <div class="section" id="get-1-boards-board-id-deltas">
   <h2>GET <span class="target" id="boards-board-id-deltas">/1/boards/[board_id]/deltas</span>
     <a class="headerlink" href="#get-1-boards-board-id-deltas" title="Permalink to this headline"></a>
@@ -2115,13 +2226,16 @@
         </li>
         <li><code class="docutils literal"><span class="pre">ixLastUpdate</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">-1</span></code> to <code class="docutils literal"><span class="pre">Infinity</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">-1</span></code>              to <code class="docutils literal"><span class="pre">Infinity</span></code></li>
           </ul>
         </li>
       </ul>
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/labels -->
+
 <div class="section" id="get-1-boards-board-id-labels">
   <h2>GET <span class="target" id="boards-board-id-labels">/1/boards/[board_id]/labels</span>
     <a class="headerlink" href="#get-1-boards-board-id-labels" title="Permalink to this headline"></a>
@@ -2133,7 +2247,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">color</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -2146,13 +2261,16 @@
         <li><code class="docutils literal"><span class="pre">limit</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">50</span></code></li>
-            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">1000</span></code></li>
+            <li><strong>Valid Values:</strong> a number from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">1000</span></code></li>
           </ul>
         </li>
       </ul>
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/labels/idLabel -->
+
 <div class="section" id="get-1-boards-board-id-labels-idlabel">
   <h2>GET <span class="target" id="boards-board-id-labels-idlabel">/1/boards/[board_id]/labels/[idLabel]</span>
     <a class="headerlink" href="#get-1-boards-board-id-labels-idlabel" title="Permalink to this headline"></a>
@@ -2169,7 +2287,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">color</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -2183,13 +2302,17 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/lists -->
+
 <div class="section" id="get-1-boards-board-id-lists">
   <h2>GET <span class="target" id="boards-board-id-lists">/1/boards/[board_id]/lists</span>
     <a class="headerlink" href="#get-1-boards-board-id-lists" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">cards</span></code> (optional)
           <ul>
@@ -2208,7 +2331,8 @@
         <li><code class="docutils literal"><span class="pre">card_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -2254,7 +2378,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -2267,44 +2392,51 @@
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/lists?cards=open&amp;card_fields=name&amp;fields=name&amp;key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[{
+  "id": "4eea4ffc91e31d174600004a",
+  "name": "To Do Soon",
+  "cards": [{
+    "id": "4eea503791e31d1746000080",
+    "name": "Finish my awesome application"
+  }]
+}, {
+  "id": "4eea4ffc91e31d174600004b",
+  "name": "Doing",
+  "cards": [{
+    "id": "4eea503d91e31d174600008f",
+    "name": "Learn about the Trello API"
+  }, {
+    "id": "4eea522c91e31d174600027e",
+    "name": "Figure out how to read a user&#39;s board list"
+  }]
+}, {
+  "id": "4eea4ffc91e31d174600004c",
+  "name": "Done",
+  "cards": [{
+    "id": "4eea501f91e31d1746000062",
+    "name": "Get a key to use in my API requests"
+  }, {
+    "id": "4eea502b91e31d1746000071",
+    "name": "Find out where the Trello API documentation is"
+  }]
+}]</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/lists?cards=open&amp;card_fields=name&amp;fields=name&amp;key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004a&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;To Do Soon&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;cards&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea503791e31d1746000080&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Finish my awesome application&quot;</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004b&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Doing&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;cards&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea503d91e31d174600008f&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Learn about the Trello API&quot;</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea522c91e31d174600027e&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Figure out how to read a user&#39;s board list&quot;</span>
-  <span class="p">}]</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea4ffc91e31d174600004c&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Done&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;cards&quot;</span><span class="o">:</span> <span class="p">[{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea501f91e31d1746000062&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Get a key to use in my API requests&quot;</span>
-  <span class="p">},</span> <span class="p">{</span>
-    <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4eea502b91e31d1746000071&quot;</span><span class="p">,</span>
-    <span class="s2">&quot;name&quot;</span><span class="o">:</span> <span class="s2">&quot;Find out where the Trello API documentation is&quot;</span>
-  <span class="p">}]</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/lists/filter -->
+
 <div class="section" id="get-1-boards-board-id-lists-filter">
   <h2>GET <span class="target" id="boards-board-id-lists-filter">/1/boards/[board_id]/lists/[filter]</span>
     <a class="headerlink" href="#get-1-boards-board-id-lists-filter" title="Permalink to this headline"></a>
@@ -2328,13 +2460,17 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/members -->
+
 <div class="section" id="get-1-boards-board-id-members">
   <h2>GET <span class="target" id="boards-board-id-members">/1/boards/[board_id]/members</span>
     <a class="headerlink" href="#get-1-boards-board-id-members" title="Permalink to this headline"></a>
   </h2>
   <ul class="simple">
     <li><strong>Required permissions:</strong> read</li>
-    <li><strong>Arguments</strong>
+    <li>
+      <strong>Arguments</strong>
       <ul>
         <li><code class="docutils literal"><span class="pre">filter</span></code> (optional)
           <ul>
@@ -2353,7 +2489,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -2374,46 +2511,52 @@
         <li><code class="docutils literal"><span class="pre">activity</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">false</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">true</span></code> or <code class="docutils literal"><span class="pre">false</span></code>; works for premium organizations only.</li>
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">true</span></code> or <code class="docutils literal"><span class="pre">false</span></code>;
+              works for premium organizations only.</li>
           </ul>
         </li>
       </ul>
     </li>
-    <li><strong>Examples</strong></li>
+    <li>
+      <strong>Examples</strong>
+      <ul>
+        <li>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/members?key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[{
+  "id": "556c8537a1928ba745504dd8",
+  "fullName": "Matt Cowan",
+  "username": "mattcowan"
+}, {
+  "id": "4ee7df74e582acdec80000b6",
+  "fullName": "David Tester",
+  "username": "davidtester"
+}, {
+  "id": "4ee7deffe582acdec80000ac",
+  "fullName": "Joe Tester",
+  "username": "joetester"
+}]</code></pre>
+          </div>
+          <div class="highlight-URL">
+            <pre>https://api.trello.com/1/boards/tBmYPSYe/members?filter=admins&amp;key=[key]&amp;token=[token]</pre>
+          </div>
+          <div class="highlight-JavaScript">
+            <pre><code class="json">[{
+  "id": "556c8537a1928ba745504dd8",
+  "fullName": "Matt Cowan",
+  "username": "mattcowan"
+}]</code></pre>
+          </div>
+        </li>
+      </ul>
+    </li>
   </ul>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/members?key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df1be582acdec80000ae&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Bob Tester&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;bobtester&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7df74e582acdec80000b6&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;David Tester&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;davidtester&quot;</span>
-<span class="p">},</span> <span class="p">{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
-  <div class="highlight-URL">
-    <div class="highlight"><pre>https://api.trello.com/1/boards/4eea4ffc91e31d1746000046/members?filter=admins&amp;key=[application_key]&amp;token=[optional_auth_token]
-</pre></div>
-  </div>
-  <div class="highlight-JavaScript">
-    <div class="highlight"><pre><span class="p">[{</span>
-  <span class="s2">&quot;id&quot;</span><span class="o">:</span> <span class="s2">&quot;4ee7deffe582acdec80000ac&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;fullName&quot;</span><span class="o">:</span> <span class="s2">&quot;Joe Tester&quot;</span><span class="p">,</span>
-  <span class="s2">&quot;username&quot;</span><span class="o">:</span> <span class="s2">&quot;joetester&quot;</span>
-<span class="p">}]</span>
-</pre></div>
-  </div>
 </div>
+
+<!-- /1/boards/id/members/filter -->
+
 <div class="section" id="get-1-boards-board-id-members-filter">
   <h2>GET <span class="target" id="boards-board-id-members-filter">/1/boards/[board_id]/members/[filter]</span>
     <a class="headerlink" href="#get-1-boards-board-id-members-filter" title="Permalink to this headline"></a>
@@ -2438,6 +2581,9 @@
     </li>
   </ul>
 </div>
+
+<!-- /1/boards/id/members/idMember/cards -->
+
 <div class="section" id="get-1-boards-board-id-members-idmember-cards">
   <h2>GET <span class="target" id="boards-board-id-members-idmember-cards">/1/boards/[board_id]/members/[idMember]/cards</span>
     <a class="headerlink" href="#get-1-boards-board-id-members-idmember-cards" title="Permalink to this headline"></a>
@@ -2448,7 +2594,8 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">actions</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">addAttachmentToCard</span></code></li>
                 <li><code class="docutils literal"><span class="pre">addChecklistToCard</span></code></li>
@@ -2512,7 +2659,8 @@
         <li><code class="docutils literal"><span class="pre">attachment_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">bytes</span></code></li>
                 <li><code class="docutils literal"><span class="pre">date</span></code></li>
@@ -2541,7 +2689,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">avatarHash,fullName,initials,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -2595,7 +2744,8 @@
         <li><code class="docutils literal"><span class="pre">board_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">name,desc,closed,idOrganization,pinned,url,prefs</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
                 <li><code class="docutils literal"><span class="pre">dateLastActivity</span></code></li>
@@ -2634,7 +2784,8 @@
         <li><code class="docutils literal"><span class="pre">list_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">closed</span></code></li>
                 <li><code class="docutils literal"><span class="pre">idBoard</span></code></li>
@@ -2662,7 +2813,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">badges</span></code></li>
                 <li><code class="docutils literal"><span class="pre">checkItemStates</span></code></li>
@@ -2712,7 +2864,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">avatarSource</span></code></li>
@@ -2803,7 +2956,8 @@
         <li><code class="docutils literal"><span class="pre">filter</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">active</span></code></li>
                 <li><code class="docutils literal"><span class="pre">admin</span></code></li>
@@ -2828,7 +2982,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -2877,7 +3032,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -2919,7 +3075,8 @@
         <li><code class="docutils literal"><span class="pre">fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">all</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">billableMemberCount</span></code></li>
                 <li><code class="docutils literal"><span class="pre">desc</span></code></li>
@@ -3000,12 +3157,12 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">name</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">desc</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">closed</span></code> (optional)
@@ -3030,7 +3187,7 @@
         </li>
         <li><code class="docutils literal"><span class="pre">idOrganization</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">prefs/permissionLevel</span></code> (optional)
@@ -3127,32 +3284,32 @@
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/green</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/yellow</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/orange</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/red</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/purple</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">labelNames/blue</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3191,7 +3348,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3208,7 +3365,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3225,7 +3382,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3242,7 +3399,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3259,7 +3416,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3276,7 +3433,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3293,7 +3450,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3310,7 +3467,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3406,7 +3563,8 @@
         <li><code class="docutils literal"><span class="pre">member_fields</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">fullName,username</span></code></li>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">avatarHash</span></code></li>
                 <li><code class="docutils literal"><span class="pre">bio</span></code></li>
@@ -3587,7 +3745,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">value</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -3826,7 +3984,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">name</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">defaultLabels</span></code> (optional)
@@ -3853,7 +4011,7 @@
         </li>
         <li><code class="docutils literal"><span class="pre">desc</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">idOrganization</span></code> (optional)
@@ -3874,7 +4032,8 @@
         </li>
         <li><code class="docutils literal"><span class="pre">powerUps</span></code> (optional)
           <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated list of:
+            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">all</span></code> or a comma-separated
+              list of:
               <ul>
                 <li><code class="docutils literal"><span class="pre">calendar</span></code></li>
                 <li><code class="docutils literal"><span class="pre">cardAging</span></code></li>
@@ -3960,7 +4119,7 @@
         <li><code class="docutils literal"><span class="pre">prefs_background</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">blue</span></code></li>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">prefs_cardAging</span></code> (optional)
@@ -3997,7 +4156,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">name</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
       </ul>
@@ -4023,7 +4182,7 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">name</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">0</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">color</span></code> (required)
@@ -4045,13 +4204,14 @@
       <ul>
         <li><code class="docutils literal"><span class="pre">name</span></code> (required)
           <ul>
-            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code> to <code class="docutils literal"><span class="pre">16384</span></code></li>
+            <li><strong>Valid Values:</strong> a string with a length from <code class="docutils literal"><span class="pre">1</span></code>              to <code class="docutils literal"><span class="pre">16384</span></code></li>
           </ul>
         </li>
         <li><code class="docutils literal"><span class="pre">pos</span></code> (optional)
           <ul>
             <li><strong>Default:</strong> <code class="docutils literal"><span class="pre">top</span></code></li>
-            <li><strong>Valid Values:</strong> A position. <code class="docutils literal"><span class="pre">top</span></code>, <code class="docutils literal"><span class="pre">bottom</span></code>, or a positive number.</li>
+            <li><strong>Valid Values:</strong> A position. <code class="docutils literal"><span class="pre">top</span></code>,
+              <code class="docutils literal"><span class="pre">bottom</span></code>, or a positive number.</li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
## Description

Fixes the example blocks that were always showing and couldn't be hidden at all, and adds syntax highlighting to them.

## Screenshots

Example blocks now start properly hidden:

![screen shot 2017-04-10 at 2 13 59 pm](https://cloud.githubusercontent.com/assets/1246035/24876012/100b13fa-1df8-11e7-9e87-d030a9e654cc.png)

When you show the example blocks they are properly highlighted as JSON:

![screen shot 2017-04-10 at 2 14 11 pm](https://cloud.githubusercontent.com/assets/1246035/24876028/1b604298-1df8-11e7-9502-76df7506b110.png)
