### PR TITLE
Add Review and Topic Clarification

### DIFF
--- a/app/templates/apis/submit-your-app.html
+++ b/app/templates/apis/submit-your-app.html
@@ -18,7 +18,7 @@
     <li>Test your Power-Up to make sure it's generally free of bugs and awkward user experiences.</li>
     <li>Review the <a href="power-ups/guidelines">Power-Up Guidelines</a> and make sure your Power-Up follows them.</li>
     <li>Review the <a href="https://trello.com/about/branding">Trello Brand Guidelines</a>.</li>
-    <li>Ensure you have highly available, responsible and scalable hosting for your Power-Up.</li>
+    <li>Ensure you have highly available, responsible, and scalable hosting for your Power-Up.</li>
   </ol>
 
   <h2>Review process</h2>
@@ -27,7 +27,9 @@
 
   <p>We review all Power-Ups before we make them available to all of our users. It's not a super formal review, it's mainly meant to help make your Power-Up a success.</p>
 
-  <p>After you've submitted your Power-Up, you should receive confirmation of the submission from the review team with 2 business days. The review team will enable the Power-Up on a Trello board and use that board to fully test the Power-Up. As the review is underway, cards will be added to the board that include issues that must be fixed before publishing and general feedback. You and your team should be invited to join that board within 4 business days of your submission. Once you've joined the board, feel free to mention the review team using @board to ask questions or if you need help with anything.</p>
+  <p>After you've submitted your Power-Up, you should receive confirmation of the submission from the review team within 2 business days. The review team will enable the Power-Up on a Trello board and use that board to fully test the Power-Up.</p>
+
+  <p>Once your Power-Up has passed review, the team will work with you to plan its launch. 🚀</p>
 
   <p>Your Power-Up may be placed under review after it's initial approval if you make significant changes to the Power-Up post-approval.</p>
 

--- a/app/templates/apis/submit-your-app.html
+++ b/app/templates/apis/submit-your-app.html
@@ -27,7 +27,7 @@
 
   <p>We review all Power-Ups before we make them available to all of our users. It's not a super formal review, it's mainly meant to help make your Power-Up a success.</p>
 
-  <p>After you've submitted your Power-Up, you should receive confirmation of the submission from the review team within 2 business days. The review team will enable the Power-Up on a Trello board and use that board to fully test the Power-Up.</p>
+  <p>After you've submitted your Power-Up, you should receive confirmation of the submission from the review team within 2 business days.</p>
 
   <p>Once your Power-Up has passed review, the team will work with you to plan its launch. 🚀</p>
 

--- a/app/templates/power-ups/topics.html
+++ b/app/templates/power-ups/topics.html
@@ -8,6 +8,7 @@
     <li><a href="#data-storage">Data Storage</a></li>
     <li><a href="#recoloring">Recoloring</a></li>
     <li><a href="#timeouts">Timeouts</a></li>
+    <li><a href="#background">Backgrounded Power-Ups</a></li>
     <li><a href="#internationalization">Internationalization</a></li>
     <li><a href="#callbacks">Callbacks</a></li>
     <li><a href="#webhooks-and-offline-access">Webhooks &amp; Offline Access</a></li>
@@ -197,6 +198,10 @@ setTimeout(function(){ window.close(); }, 1000);</code></pre>
   <p>Additionally, you should make sure that your manifest file and index connector can be loaded by Trello as quickly as possible. You should have these served within one second; Trello will stop waiting for a response after 10 seconds.</p>
   <hr/>
 
+  <h2 id="background">Power-Ups Running In Browser Background</h2>
+  <p>Many browsers <a href="https://developers.google.com/web/updates/2017/03/background_tabs" targe="_blank">throttle the CPU usage</a> of tabs open in the background. This causes Power-Up communication to be slowed drastically and causes them to be more prone to time outs. To mitiage potential problems, the Power-Up client library will only attempt to communicate with your Power-Up if the Trello board on which the Power-Up is enabled <a href="https://www.w3.org/TR/page-visibility/" target="_blank">is visible</a>.</p>
+  <hr/>
+   
   <h2 id="internationalization">Internationalization</h2>
   <p>Trello Power-Ups were designed with Internationalization in mind. When creating a plugin or iframe, you can optionally pass in the options argument one of the following:</p>
   <p>localization object</p>


### PR DESCRIPTION
We had a few questions around what happens when a Power-Up is approved. Some folks were hesitant to submit a Power-Up because they thought that if it passed review it was immediately launched. Wanted to let people know that it isn't an instant process and that the Trello team works with them to ensure that the launch is timed well and goes off smoothly.

@hamidp I'm pulling out all of the stuff about using a review board as that is no longer the process.

@mpcowan Will you put eyes on my throttling copy?