### PR TITLE
remove dueComplete from POST params list

### DIFF
--- a/app/templates/docs/card.html
+++ b/app/templates/docs/card.html
@@ -1710,11 +1710,6 @@
             <li><strong>Valid Values:</strong> A date, or <code class="docutils literal"><span class="pre">null</span></code></li>
           </ul>
         </li>
-        <li><code class="docutils literal"><span class="pre">dueComplete</span></code> (optional)
-          <ul>
-            <li><strong>Valid Values:</strong> <code class="docutils literal"><span class="pre">true</span></code> or <code class="docutils literal"><span class="pre">false</span></code></li>
-          </ul>
-        </li>
         <li><code class="docutils literal"><span class="pre">idList</span></code> (required)
           <ul>
             <li><strong>Valid Values:</strong> id of the list that the card should be added to</li>


### PR DESCRIPTION
dueComplete is not a valid POST parameter. You can only set dueComplete in PUT
requests

## Description

A few sentences describing the purpose of this pull request's commits.

## Issues Addressed

A list of the issues the PR addresses:

issue |
----- |
[github.com/trello/api-docs/issues](github.com/trello/api-docs/issues) |
[github.com/trello/api-docs/issues](github.com/trello/api-docs/issues) |

## Screenshots

A screenshot of the changes.